### PR TITLE
Fixed blog nav menu highlight on recent posts section

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -4,6 +4,10 @@
     for (const link of links) {
         if (currentUrl.indexOf(link.href) !== -1) {
             link.classList.add('active')
+        } else {
+            if(currentUrl.indexOf("blog") !== -1 && link.href.indexOf("#posts")!== -1) {
+                link.classList.add('active')
+            }
         }
     }
 }())

--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -20,7 +20,7 @@
 
 [[main]]
   name = "Blog"
-  url = "blog/"
+  url = "#posts"
   weight = 4
 
 [[main]]


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixed blog navigation menu highlight, when recent posts section displayed in home page.


* **What is the current behavior?** (You can also link to an open issue here)
Blog navigation menu is not getting highlight, when recent posts section displayed in home page.


* **What is the new behavior (if this is a feature change)?**
Blog navigation menu is getting highlight, when recent posts section displayed in home page.
