### PR TITLE
fix typo in cli page

### DIFF
--- a/content/en/docs/cli.md
+++ b/content/en/docs/cli.md
@@ -56,7 +56,7 @@ vcctl job suspend --name job-name [--namespace job-namespace]
 vcctl job resume --name job-name [--namespace job-namespace]
 
 ```html
-# vcctl job suspend --name job-1 --namespace default
+# vcctl job resume --name job-1 --namespace default
 ```
 
 ### Running a job

--- a/content/zh/docs/cli.md
+++ b/content/zh/docs/cli.md
@@ -52,7 +52,7 @@ delete job job-1 successfully
 ### 消费一个Job (与"vcctl job suspend"相反)
 
 ```html
-# vcctl job suspend --name job-1 --namespace default
+# vcctl job resume --name job-1 --namespace default
 ```
 
 ### 运行一个Job


### PR DESCRIPTION
change "suspend" to "resume" in the resuming guide part, this should be a typo ......

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
<!--
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
-->

* **What this PR does / why we need it**:

* **Which issue(s) this PR fixes**:
