### PR TITLE
add hugo version considerations in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ brew install hugo
 
 #### Debian:
 
-1. Download the latest Debian package from the [Hugo website][hugo-install].
-  For example, `hugo_0.57.2_Linux-64bit.deb`.
+1. Download the Debian package from the [Hugo website][hugo-install].
+   Make sure to install the Hugo version specified by the `HUGO_VERSION` environment variable in the [`netlify.toml`](netlify.toml#L6) file.
+   For example, [hugo_0.57.2_Linux-64bit.deb][hugo_0.57.2_Linux-64bit.deb].
 1. Install the package using `dpkg`:
 
     ```
@@ -95,9 +96,11 @@ local machine, then use your local repo as input to your Hugo web server:
   local website reflects the files in the current branch.
 
 Useful Hugo docs:
-- [Hugo installation guide][hugo-install]
+- [Hugo installation guide](https://gohugo.io/getting-started/installing/)
 - [Hugo basic usage](https://gohugo.io/getting-started/usage/)
 - [Hugo site directory structure](https://gohugo.io/getting-started/directory-structure/)
 - [hugo server reference](https://gohugo.io/commands/hugo_server/)
 - [hugo new reference](https://gohugo.io/commands/hugo_new/)
 
+[hugo-install]: https://gohugo.io/getting-started/installing/
+[hugo_0.57.2_Linux-64bit.deb]: https://github.com/gohugoio/hugo/releases/download/v0.57.2/hugo_0.57.2_Linux-64bit.deb


### PR DESCRIPTION
Signed-off-by: Xieql <xieqianglong@huawei.com>

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
/kind documentation

* **What this PR does / why we need it**:
I couldn't start the website with the latest version of hugo, but it returned to normal after using the same version of hugo as the configuration. And there is also a reminder of this hugo version on the k8s document that also uses hugo https://github.com/kubernetes/website
It has been verified on Windows system and Debian system: it is necessary to keep the hugo version consistent
I guess it is because the current version 0.104.1 is too different from the previous version 0.57.2.
* **Which issue(s) this PR fixes**:
