### PR TITLE
Adjusted Top Alignment in Mobile View #353

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -189,6 +189,12 @@ ul.share li i {
 .docs-article-container {
     max-width: 100%;
 }
+@media (max-width: 1200px) {
+
+    .container-fluid.docs {
+      padding-top: 0 !important; 
+    }
+  }
 
 /*********************************
 * Blog list 


### PR DESCRIPTION
Fixed https://github.com/volcano-sh/website/issues/352

Hi @Arhell @Monokaix , I guess I did not cleary communicated my fix.

whenever we open https://volcano.sh/en/docs/ in mobile view their is alignment issue there in ,
specified in https://github.com/volcano-sh/website/issues/352

Example:-

![Screenshot from 2025-02-15 11-38-27](https://github.com/user-attachments/assets/8e1f2e62-19a7-4a3a-8338-188ff12740e3)

to :-
![Screenshot from 2025-02-15 11-40-46](https://github.com/user-attachments/assets/3041e4b9-da9c-4387-a402-d8596ca0d1e0)

