### PR TITLE
fix: improve language switching in single blog pages

### DIFF
--- a/themes/academic/layouts/partials/navbar.html
+++ b/themes/academic/layouts/partials/navbar.html
@@ -148,7 +148,6 @@
 
 
           <!-- 翻译 -->
-
           <li class="nav-item dropdown">
             <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" aria-haspopup="true">
               <i class="fas fa-globe" aria-hidden="true"></i>
@@ -157,10 +156,21 @@
             <ul class="dropdown-menu">
               {{ range .Translations }}
               <li class="dropdown-item my-0 py-0 mx-0 px-0">
-                <a href="{{ .Permalink }}"{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}>
+                <a href="{{ .RelPermalink }}"{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}>
                   <span>{{ index .Site.Data.i18n.languages .Lang }}</span>
                 </a>
               </li>
+              {{ end }}
+              {{ if not .IsTranslated }}
+                {{ range .Site.Languages }}
+                  {{ if ne .Lang $.Lang }}
+                    <li class="dropdown-item my-0 py-0 mx-0 px-0">
+                      <a href="{{ . | relURL }}">
+                        <span>{{ index $.Site.Data.i18n.languages .Lang }}</span>
+                      </a>
+                    </li>
+                  {{ end }}
+                {{ end }}
               {{ end }}
             </ul>
           </li>


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines


* **Bug Fix: Multi-language switching error in a signle blog page #373 
** 
<!--
/kind bug
-->

* **What this PR does / why we need it**:
This PR fixes the language switching functionality in single blog pages. Previously, when a page didn't have a translation in Chinese, the language switcher would not show the Chinese option at all. This made it impossible for users to switch to Chinese for pages that weren't translated.

**Changes Made**
1. Modified the language switcher in `themes/academic/layouts/partials/navbar.html` to:
   - Use `.RelPermalink` instead of `.Permalink` for better URL handling
   - Add a fallback for untranslated content that shows all available languages
   - Properly handle language switching in single blog pages

2. Added a new section that shows all available languages in the dropdown, even if a translation doesn't exist. For untranslated pages, clicking on the Chinese option will now redirect to the Chinese home page instead of showing no option at all.

**Before**
- Language switcher would not show Chinese option for pages without translations
- Users couldn't switch to Chinese for untranslated pages
- Some pages had broken language switching functionality

**After**
- Language switcher always shows all available languages
- For untranslated pages, clicking Chinese will redirect to the Chinese home page
- Consistent language switching behavior across all pages

Fixes #373 
