### PR TITLE
Add Cron VolcanoJob Concept

### DIFF
--- a/content/en/docs/cron_volcanoJob.md
+++ b/content/en/docs/cron_volcanoJob.md
@@ -56,43 +56,43 @@ kubectl get vcjob
 ### Key Fields
 * schedule
 
-Required. The cron schedule string for Volcano Job execution. Uses standard cron format.
+    Required. The cron schedule string for Volcano Job execution. Uses standard cron format.
 
 * timeZone
 
-Optional. The time zone name for the schedule. Defaults to the local time zone of the kube-controller-manager.
+    Optional. The time zone name for the schedule. Defaults to the local time zone of the kube-controller-manager.
 
 * concurrencyPolicy
 
-Optional. Specifies how to manage concurrent executions of jobs created by the Cron VolcanoJob. Must be one of the following:
+    Optional. Specifies how to manage concurrent executions of jobs created by the Cron VolcanoJob. Must be one of the following:
+    *   Allow (default): Allow concurrent runs  
+    *   Forbid: Skip new run if previous job hasn‘t completed  
+    *   Replace: Cancel currently running job and start new
 
-<div style="margin-left: 20px;">
-
-- llow (default): Allow concurrent runs  
-- Forbid: Skip new run if previous job hasn't completed  
-- Replace: Cancel currently running job and start new
-
-</div>
+<!-- -->
 
 * startingDeadlineSeconds
 
-Optional. Deadline in seconds for starting the job if it misses its scheduled time.
+    Optional. Deadline in seconds for starting the job if it misses its scheduled time.
 
 * suspend
 
-Optional. If set to true, all subsequent executions will be suspended.
+    Optional. If set to true, all subsequent executions will be suspended.
 
 * jobTemplate
 
-Required. The template for creating Volcano Jobs. Contains the complete Volcano Job specification.
+    Required. The template for creating Volcano Jobs. Contains the complete Volcano Job specification.
 
 * successfulJobsHistoryLimit
 
-Optional. Number of successful finished jobs to retain. Defaults to 3.
+    Optional. Number of successful finished jobs to retain. Defaults to 3.
 
 * failedJobsHistoryLimit
 
-Optional. Number of failed finished jobs to retain. Defaults to 1.
+    Optional. Number of failed finished jobs to retain. Defaults to 1.
+
+<!-- -->
+
 ### Usage
 * Periodic Model Training
 

--- a/content/zh/docs/cron_volcanoJob.md
+++ b/content/zh/docs/cron_volcanoJob.md
@@ -56,43 +56,43 @@ kubectl get vcjob
 ### 关键字段
 * schedule
 
-必需。用于volcano job 执行的 cron 计划字符串。使用标准 cron 格式。
+    必需。用于volcano job 执行的 cron 计划字符串。使用标准 cron 格式。
 
 * timeZone
 
-可选。调度计划的时区名称。默认为 kube-controller-manager 的本地时区。
+    可选。调度计划的时区名称。默认为 kube-controller-manager 的本地时区。
 
-* concurrencyPolicy
+*   concurrencyPolicy
 
-可选。指定如何管理 Cron VolcanoJob 创建的 job 的并发执行。为下列规则中的一种：
+    可选。指定如何管理 Cron VolcanoJob 创建的 job 的并发执行。为下列规则中的一种：
+    *   Allow（默认）：允许并发运行
+    *   Forbid：禁止并发运行，跳过新周期的执行
+    *   Replace：取消当前运行的 job，并用新的 job 替换它
 
-<div style="margin-left: 20px;">
-
-- Allow（默认）：允许并发运行  
-- Forbid：禁止并发运行，跳过新周期的执行  
-- Replace：取消当前运行的 job，并用新的 job 替换它
-
-</div>
+<!-- -->
 
 * startingDeadlineSeconds
 
-可选。如果 job 错过其计划时间，启动 job 的截止时间（秒）。
+    可选。如果 job 错过其计划时间，启动 job 的截止时间（秒）。
 
 * suspend
 
-可选。如果设置为 true，所有后续执行将被暂停。
+    可选。如果设置为 true，所有后续执行将被暂停。
 
 * jobTemplate
 
-必需。用于创建 Volcano Job 的模板。包含完整的 Volcano Job 规范。
+    必需。用于创建 Volcano Job 的模板。包含完整的 Volcano Job 规范。
 
 * successfulJobsHistoryLimit
 
-可选。要保留的成功完成 job 的数量。默认为 3。
+    可选。要保留的成功完成 job 的数量。默认为 3。
 
 * failedJobsHistoryLimit
 
-可选。要保留的失败完成 job 的数量。默认为 1。
+    可选。要保留的失败完成 job 的数量。默认为 1。
+
+<!-- -->
+
 ### 使用场景
 * 定期模型训练
 

--- a/doc/concepts/cron_volcanoJob.md
+++ b/doc/concepts/cron_volcanoJob.md
@@ -1,3 +1,18 @@
++++
+title = "Cron VolcanoJob"
+date = 2025-11-19
+lastmod = 2025-11-19
+
+draft = false
+toc = true
+type = "docs"
+
+linktitle = "Cron VolcanoJob"
+[menu.docs]
+  parent = "concepts"
+  weight = 4
++++
+
 ### 定义
 Cron VolcanoJob, 简称cronvcjob，cronvj，是Volcano自定义的资源类型。用户现在可以根据预定义的调度计划定期创建和运行Volcano Job，类似于Kubernetes原生的CronJob，以实现批量计算任务(如AI和大数据)的定期执行。
 ### 样例
@@ -41,43 +56,43 @@ kubectl get vcjob
 ### 关键字段
 * schedule
 
-必需。用于volcano job 执行的 cron 计划字符串。使用标准 cron 格式。
+    必需。用于volcano job 执行的 cron 计划字符串。使用标准 cron 格式。
 
 * timeZone
 
-可选。调度计划的时区名称。默认为 kube-controller-manager 的本地时区。
+    可选。调度计划的时区名称。默认为 kube-controller-manager 的本地时区。
 
-* concurrencyPolicy
+*   concurrencyPolicy
 
-可选。指定如何管理 Cron VolcanoJob 创建的 job 的并发执行。为下列规则中的一种：
+    可选。指定如何管理 Cron VolcanoJob 创建的 job 的并发执行。为下列规则中的一种：
+    *   Allow（默认）：允许并发运行
+    *   Forbid：禁止并发运行，跳过新周期的执行
+    *   Replace：取消当前运行的 job，并用新的 job 替换它
 
-<div style="margin-left: 20px;">
-
-- Allow（默认）：允许并发运行  
-- Forbid：禁止并发运行，跳过新周期的执行  
-- Replace：取消当前运行的 job，并用新的 job 替换它
-
-</div>
+<!-- -->
 
 * startingDeadlineSeconds
 
-可选。如果 job 错过其计划时间，启动 job 的截止时间（秒）。
+    可选。如果 job 错过其计划时间，启动 job 的截止时间（秒）。
 
 * suspend
 
-可选。如果设置为 true，所有后续执行将被暂停。
+    可选。如果设置为 true，所有后续执行将被暂停。
 
 * jobTemplate
 
-必需。用于创建 Volcano Job 的模板。包含完整的 Volcano Job 规范。
+    必需。用于创建 Volcano Job 的模板。包含完整的 Volcano Job 规范。
 
 * successfulJobsHistoryLimit
 
-可选。要保留的成功完成 job 的数量。默认为 3。
+    可选。要保留的成功完成 job 的数量。默认为 3。
 
 * failedJobsHistoryLimit
 
-可选。要保留的失败完成 job 的数量。默认为 1。
+    可选。要保留的失败完成 job 的数量。默认为 1。
+
+<!-- -->
+
 ### 使用场景
 * 定期模型训练
 


### PR DESCRIPTION
## **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines

## **What kind of change does this PR introduce?** 
/kind documentation

## **What this PR does / why we need it**:
This PR adds comprehensive documentation for the newly introduced Cron VolcanoJob feature in Volcano v1.13, including both Chinese and English versions.

**Changes included:**
- Add Chinese documentation
- Add English documentation
- Introduce Cron VolcanoJob definition, purpose and use cases
- Explain all key fields (schedule, timeZone, concurrencyPolicy, startingDeadlineSeconds, history limits, etc.)
- Provide usage examples with YAML manifests
- Include kubectl commands for managing Cron VolcanoJobs

## **Which issue(s) this PR fixes**:
Fixes #429

## **Special notes for your reviewer**:
- Documentation follows Volcano Job documentation style
- Both Chinese and English versions are provided
