### PR TITLE
docs: Add missing plugin documentation for resource-strategy-fit, capacity,…

### DIFF
--- a/content/en/docs/plugins/capacity.md
+++ b/content/en/docs/plugins/capacity.md
@@ -10,8 +10,7 @@ type = "docs"  # Do not modify.
 
 # Add menu entry to sidebar.
 linktitle = "Capacity"
-[menu.docs]
-  parent = "plugins"
+[menu.plugins]
   weight = 2
 +++
 

--- a/content/en/docs/plugins/deviceshare.md
+++ b/content/en/docs/plugins/deviceshare.md
@@ -10,8 +10,7 @@ type = "docs"  # Do not modify.
 
 # Add menu entry to sidebar.
 linktitle = "Device Share"
-[menu.docs]
-  parent = "plugins"
+[menu.plugins]
   weight = 3
 +++
 

--- a/content/en/docs/plugins/extender.md
+++ b/content/en/docs/plugins/extender.md
@@ -10,8 +10,7 @@ type = "docs"  # Do not modify.
 
 # Add menu entry to sidebar.
 linktitle = "Extender"
-[menu.docs]
-  parent = "plugins"
+[menu.plugins]
   weight = 4
 +++
 

--- a/content/en/docs/plugins/nodegroup.md
+++ b/content/en/docs/plugins/nodegroup.md
@@ -10,8 +10,7 @@ type = "docs"  # Do not modify.
 
 # Add menu entry to sidebar.
 linktitle = "Node Group"
-[menu.docs]
-  parent = "plugins"
+[menu.plugins]
   weight = 5
 +++
 

--- a/content/en/docs/plugins/resource-strategy-fit.md
+++ b/content/en/docs/plugins/resource-strategy-fit.md
@@ -10,8 +10,7 @@ type = "docs"  # Do not modify.
 
 # Add menu entry to sidebar.
 linktitle = "Resource Strategy Fit"
-[menu.docs]
-  parent = "plugins"
+[menu.plugins]
   weight = 1
 +++
 

--- a/content/en/docs/plugins/resourcequota.md
+++ b/content/en/docs/plugins/resourcequota.md
@@ -10,8 +10,7 @@ type = "docs"  # Do not modify.
 
 # Add menu entry to sidebar.
 linktitle = "Resource Quota"
-[menu.docs]
-  parent = "plugins"
+[menu.plugins]
   weight = 7
 +++
 

--- a/content/en/docs/plugins/usage.md
+++ b/content/en/docs/plugins/usage.md
@@ -10,8 +10,7 @@ type = "docs"  # Do not modify.
 
 # Add menu entry to sidebar.
 linktitle = "Usage"
-[menu.docs]
-  parent = "plugins"
+[menu.plugins]
   weight = 6
 +++
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
/kind documentation

* **What this PR does / why we need it**:
Adds documentation for 7 missing scheduler plugins that exist in the volcano-sh/volcano repository but were not documented on the website. This aligns the website documentation with available plugins.

* **Which issue(s) this PR fixes**:
#427

Addresses missing plugin documentation to improve user understanding and usage of available Volcano scheduler plugins.

// @JesseStutler 