### PR TITLE
docs: add deviceshare dependency warning to Predicate plugin documentation

### DIFF
--- a/content/en/docs/plugins.md
+++ b/content/en/docs/plugins.md
@@ -114,6 +114,9 @@ Anti-affinity：
 
 The Predicate Plugin calls the PredicateGPU with pod and nodeInfo as parameters to evaluate and pre-select jobs based on the results.
 
+> ⚠️ **Warning**
+> The deviceshare plugin has a dependency on the Predicate plugin and cannot function without it being enabled.
+
 #### Scenario
 
 In AI scenarios where GPU resources are required, the Predicate Plugin can quickly filter out those that require the GPU for centralized scheduling.

--- a/content/zh/docs/plugins.md
+++ b/content/zh/docs/plugins.md
@@ -110,6 +110,9 @@ Anti-affinity：
 
 Predicate plugin通过pod、nodeInfo作为参数，调用predicateGPU，根据计算结果对作业进行评估预选。
 
+> ⚠️ **警告**
+> deviceshare插件依赖于Predicate插件，不能在Predicate插件未启用的情况下独立运行。
+
 #### 场景
 
 在AI的应用场景下，GPU资源是必需，Predicate plugin可以快速筛选出来需要GPU的进行集中调度。


### PR DESCRIPTION
### Summary
The deviceshare plugin has an implicit dependency on the Predicate plugin, but this was not documented previously. As a result, users could enable deviceshare without enabling Predicate, leading to configuration errors and unexpected behavior.

### Changes
- Added a clear warning to the Predicate plugin documentation stating that the deviceshare plugin depends on it
- Updated both English and Chinese versions of the plugins documentation to keep them in sync

### Rationale
Making this dependency explicit helps users avoid misconfiguration and improves the robustness of the plugin ecosystem by clearly documenting required plugin relationships.

Fixes #410 
