### PR TITLE
[BugFix]: Remove leading zeros from dateday in TOML front matter

### DIFF
--- a/content/en/blog/Meet  Cloud Native Batch Computing with Volcano in AI & Big Data Scenarios.md
+++ b/content/en/blog/Meet  Cloud Native Batch Computing with Volcano in AI & Big Data Scenarios.md
@@ -7,7 +7,7 @@ date = 2024-03-08
 lastmod = 2024-03-08
 datemonth = "Mar"
 dateyear = "2024"
-dateday = 08
+dateday = 8
 
 draft = false  # Is this a draft? true/false
 toc = true  # Show table of contents? true/false

--- a/content/en/blog/Volcano-1.11.0-release.md
+++ b/content/en/blog/Volcano-1.11.0-release.md
@@ -7,7 +7,7 @@ date = 2025-02-07
 lastmod = 2025-02-07
 datemonth = "Feb"
 dateyear = "2025"
-dateday = 07
+dateday = 7
 
 draft = false  # Is this a draft? true/false
 toc = true  # Show table of contents? true/false

--- a/content/en/blog/how-volcano-boosts-distributed-training-and-inference-performance.md
+++ b/content/en/blog/how-volcano-boosts-distributed-training-and-inference-performance.md
@@ -7,7 +7,7 @@ date = 2025-04-01
 lastmod = 2025-04-01
 datemonth = "Apr"
 dateyear = "2025"
-dateday = 01
+dateday = 1
 
 draft = false  # Is this a draft? true/false
 toc = true  # Show table of contents? true/false

--- a/content/zh/blog/Quick-Start-Volcano.md
+++ b/content/zh/blog/Quick-Start-Volcano.md
@@ -7,7 +7,7 @@ date = 2019-03-28
 lastmod = 2020-09-07
 datemonth = "Sep"
 dateyear = "2020"
-dateday = 07
+dateday = 7
 
 draft = false  # Is this a draft? true/false
 toc = true  # Show table of contents? true/false

--- a/content/zh/blog/Volcano-1.11.0-release.md
+++ b/content/zh/blog/Volcano-1.11.0-release.md
@@ -7,7 +7,7 @@ date = 2025-02-07
 lastmod = 2025-02-07
 datemonth = "Feb"
 dateyear = "2025"
-dateday = 07
+dateday = 7
 
 draft = false  # Is this a draft? true/false
 toc = true  # Show table of contents? true/false

--- a/content/zh/blog/kube-batch-customers.md
+++ b/content/zh/blog/kube-batch-customers.md
@@ -7,7 +7,7 @@ date = 2019-01-28
 lastmod = 2020-09-07
 datemonth = "Sep"
 dateyear = "2020"
-dateday = 07
+dateday = 7
 
 draft = false  # Is this a draft? true/false
 toc = true  # Show table of contents? true/false

--- a/content/zh/blog/kube-batch-startup.md
+++ b/content/zh/blog/kube-batch-startup.md
@@ -7,7 +7,7 @@ date = 2019-01-28
 lastmod = 2020-09-07
 datemonth = "Sep"
 dateyear = "2020"
-dateday = 07
+dateday = 7
 
 draft = false  # Is this a draft? true/false
 toc = true  # Show table of contents? true/false


### PR DESCRIPTION
## Description

Removes leading zeros from `dateday` values in blog post TOML front matter to comply with TOML v1.0.0 specification.

## Why This Change is Needed

**The Problem:**
- Blog posts contain `dateday = 01`, `dateday = 07` etc. in TOML front matter
- Leading zeros violate TOML v1.0.0 spec (ambiguous with octal notation)
- Hugo v0.123.7+ fails to build: `Error: unmarshal failed: toml: expected newline`
- Blocks local development with modern Hugo and future version upgrades

**The Fix:**
- Change `dateday = 07` → `dateday = 7` (remove leading zeros)
- Backward compatible with Hugo v0.57.2 (current version in netlify.toml)
- Enables modern Hugo usage and future upgrades

## Checklist

- [x] Commit message follows guidelines
- [x] Tested with Hugo v0.57.2 and v0.123.7+

## Type of Change

/kind bug

## Which Issue(s) This PR Fixes

Fixes #448