### PR TITLE
docs: fix broken internal link in contribution.md

### DIFF
--- a/content/en/docs/contribution.md
+++ b/content/en/docs/contribution.md
@@ -80,7 +80,7 @@ There are [multiple repositories](https://github.com/volcano-sh/) within the Vol
 For example, in [Volcano-Issues](https://github.com/volcano-sh/volcano), you can choose issues labeled with [help wanted](https://github.com/volcano-sh/volcano/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) or [good first issue](https://github.com/volcano-sh/volcano/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
 New contributors are welcome to work on these issues.
 
-Another good way to start is to find a document that needs improvement, for example, a document that is missing a link or contains a broken link. For details on the workflow, see [Contribution Workflow](#contributor-workflow).
+Another good way to start is to find a document that needs improvement, for example, a document that is missing a link or contains a broken link. For details on the workflow, see [Contribution Workflow](#contribution-workflow).
 
 #### Work on an Issue
 


### PR DESCRIPTION
Fixes broken anchor reference to Contribution Workflow section.

Fixes #462

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
<!--
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
-->
/kind documentation


* **What this PR does / why we need it**:
This PR fixes a broken internal Markdown link in
`content/en/docs/contribution.md` by correcting the anchor reference for the
**Contribution Workflow** section. The previous link pointed to a non-existent
anchor and did not navigate to the intended section, which could confuse new
contributors.


* **Which issue(s) this PR fixes**:
Fixes #462
