### PR TITLE
fix: correct typo in vcjob completed state description

### DIFF
--- a/content/zh/docs/v1-10-0/vcjob.md
+++ b/content/zh/docs/v1-10-0/vcjob.md
@@ -135,7 +135,7 @@ completing表示job中至少有minAvailable个数的task已经完成，该job正
 
 * completed
 
-completing表示job中至少有minAvailable个数的task已经完成，该job已经完成了最后的清理工作。
+completed表示job中至少有minAvailable个数的task已经完成，该job已经完成了最后的清理工作。
 
 * terminating
 

--- a/content/zh/docs/v1-11-0/vcjob.md
+++ b/content/zh/docs/v1-11-0/vcjob.md
@@ -136,7 +136,7 @@ completing表示job中至少有minAvailable个数的task已经完成，该job正
 
 * completed
 
-completing表示job中至少有minAvailable个数的task已经完成，该job已经完成了最后的清理工作。
+completed表示job中至少有minAvailable个数的task已经完成，该job已经完成了最后的清理工作。
 
 * terminating
 

--- a/content/zh/docs/v1-12-0/vcjob.md
+++ b/content/zh/docs/v1-12-0/vcjob.md
@@ -136,7 +136,7 @@ completing表示job中至少有minAvailable个数的task已经完成，该job正
 
 * completed
 
-completing表示job中至少有minAvailable个数的task已经完成，该job已经完成了最后的清理工作。
+completed表示job中至少有minAvailable个数的task已经完成，该job已经完成了最后的清理工作。
 
 * terminating
 

--- a/content/zh/docs/v1-7-0/vcjob.md
+++ b/content/zh/docs/v1-7-0/vcjob.md
@@ -136,7 +136,7 @@ completing表示job中至少有minAvailable个数的task已经完成，该job正
 
 * completed
 
-completing表示job中至少有minAvailable个数的task已经完成，该job已经完成了最后的清理工作。
+completed表示job中至少有minAvailable个数的task已经完成，该job已经完成了最后的清理工作。
 
 * terminating
 

--- a/content/zh/docs/v1-8-2/vcjob.md
+++ b/content/zh/docs/v1-8-2/vcjob.md
@@ -136,7 +136,7 @@ completing表示job中至少有minAvailable个数的task已经完成，该job正
 
 * completed
 
-completing表示job中至少有minAvailable个数的task已经完成，该job已经完成了最后的清理工作。
+completed表示job中至少有minAvailable个数的task已经完成，该job已经完成了最后的清理工作。
 
 * terminating
 

--- a/content/zh/docs/v1-9-0/vcjob.md
+++ b/content/zh/docs/v1-9-0/vcjob.md
@@ -135,7 +135,7 @@ completing表示job中至少有minAvailable个数的task已经完成，该job正
 
 * completed
 
-completing表示job中至少有minAvailable个数的task已经完成，该job已经完成了最后的清理工作。
+completed表示job中至少有minAvailable个数的task已经完成，该job已经完成了最后的清理工作。
 
 * terminating
 

--- a/content/zh/docs/vcjob.md
+++ b/content/zh/docs/vcjob.md
@@ -136,7 +136,7 @@ completing表示job中至少有minAvailable个数的task已经完成，该job正
 
 * completed
 
-completing表示job中至少有minAvailable个数的task已经完成，该job已经完成了最后的清理工作。
+completed表示job中至少有minAvailable个数的task已经完成，该job已经完成了最后的清理工作。
 
 * terminating
 


### PR DESCRIPTION
The completed state description incorrectly started with "completing" instead of "completed" across all versioned docs.


* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
<!--
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design
-->
/kind documentation

* **What this PR does / why we need it**:
Fix a typo in vcjob docs: under the `completed` state section, the description incorrectly starts with "completing" instead of "completed". Fixed across all versioned docs (v1-7-0, v1-8-2, v1-9-0, v1-10-0, v1-11-0, v1-12-0, and latest).

* **Which issue(s) this PR fixes**:
None