### PR TITLE
fix: resolve template and frontmatter errors for hugo 0.123 compatibi…

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -90,3 +90,8 @@ preserveTaxonomyNames = true
 [[params.versions]]
   name = "v1.7.0"
   url = "/en/docs/v1-7-0"
+
+[markup]
+  [markup.highlight]
+    style = "github"
+    noClasses = true

--- a/content/en/blog/Meet  Cloud Native Batch Computing with Volcano in AI & Big Data Scenarios.md
+++ b/content/en/blog/Meet  Cloud Native Batch Computing with Volcano in AI & Big Data Scenarios.md
@@ -7,7 +7,7 @@ date = 2024-03-08
 lastmod = 2024-03-08
 datemonth = "Mar"
 dateyear = "2024"
-dateday = 08
+dateday = 8
 
 draft = false  # Is this a draft? true/false
 toc = true  # Show table of contents? true/false

--- a/content/en/blog/Volcano-1.11.0-release.md
+++ b/content/en/blog/Volcano-1.11.0-release.md
@@ -7,7 +7,7 @@ date = 2025-02-07
 lastmod = 2025-02-07
 datemonth = "Feb"
 dateyear = "2025"
-dateday = 07
+dateday = 7
 
 draft = false  # Is this a draft? true/false
 toc = true  # Show table of contents? true/false

--- a/content/en/blog/how-volcano-boosts-distributed-training-and-inference-performance.md
+++ b/content/en/blog/how-volcano-boosts-distributed-training-and-inference-performance.md
@@ -7,7 +7,7 @@ date = 2025-04-01
 lastmod = 2025-04-01
 datemonth = "Apr"
 dateyear = "2025"
-dateday = 01
+dateday = 1
 
 draft = false  # Is this a draft? true/false
 toc = true  # Show table of contents? true/false

--- a/content/zh/blog/Quick-Start-Volcano.md
+++ b/content/zh/blog/Quick-Start-Volcano.md
@@ -7,7 +7,7 @@ date = 2019-03-28
 lastmod = 2020-09-07
 datemonth = "Sep"
 dateyear = "2020"
-dateday = 07
+dateday = 7
 
 draft = false  # Is this a draft? true/false
 toc = true  # Show table of contents? true/false

--- a/content/zh/blog/Volcano-1.11.0-release.md
+++ b/content/zh/blog/Volcano-1.11.0-release.md
@@ -7,7 +7,7 @@ date = 2025-02-07
 lastmod = 2025-02-07
 datemonth = "Feb"
 dateyear = "2025"
-dateday = 07
+dateday = 7
 
 draft = false  # Is this a draft? true/false
 toc = true  # Show table of contents? true/false
@@ -161,7 +161,7 @@ Volcano将持续优化网络拓扑感知调度功能，未来计划：
 
 设计文档：**[Network Topology Aware Scheduling](https://volcano.sh/en/docs/network_topology_aware_scheduling/)**。
 
-使用文档：**[Network Topology Aware Scheduling | Volcano](*https://volcano.sh/en/docs/network_topology_aware_scheduling/*)**。
+使用文档：**[Network Topology Aware Scheduling | Volcano](https://volcano.sh/en/docs/network_topology_aware_scheduling/)**。
 
 由衷感谢社区开发者: **@ecosysbin, @weapons97, @Xu-Wentao,@penggu, @JesseStutler, @Monokaix** 对该特性的贡献！
 

--- a/content/zh/blog/kube-batch-customers.md
+++ b/content/zh/blog/kube-batch-customers.md
@@ -7,7 +7,7 @@ date = 2019-01-28
 lastmod = 2020-09-07
 datemonth = "Sep"
 dateyear = "2020"
-dateday = 07
+dateday = 7
 
 draft = false  # Is this a draft? true/false
 toc = true  # Show table of contents? true/false

--- a/content/zh/blog/kube-batch-startup.md
+++ b/content/zh/blog/kube-batch-startup.md
@@ -7,7 +7,7 @@ date = 2019-01-28
 lastmod = 2020-09-07
 datemonth = "Sep"
 dateyear = "2020"
-dateday = 07
+dateday = 7
 
 draft = false  # Is this a draft? true/false
 toc = true  # Show table of contents? true/false

--- a/layouts/partials/footer_section.html
+++ b/layouts/partials/footer_section.html
@@ -8,7 +8,7 @@
   <!-- <p class="powered-by"> -->
     <!-- {{ with .Site.Copyright }}{{ . | markdownify}}  {{ end }} -->
   {{ if .IsHome }}
-    {{ if eq .Language.ContentDir "content/en"}}
+    {{ if eq .Language.Lang "en" }}
        <div style="font-size: 18px;color: #fff;text-align: center;margin-top: 20px;">Volcano is a <a href="https://www.cncf.io/" style="color: #c8000b;">Cloud Native Computing Foundation</a> incubating project.</div>
        <div style="margin: 52px 0 36px;">
          <img src="/img/logo_cloudnative.png" alt="cloudnative logo" width="auto;" height="100px;" style="margin: 0 auto;">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="generator" content="Source Themes Academic {{ .Site.Data.academic.version }}">
-  {{ .Hugo.Generator }}
+  {{ hugo.Generator }}
 
   {{ $scr := .Scratch }}
 
@@ -131,10 +131,10 @@
   {{ end }}
   {{ end }}
 
-  {{ if or .Site.RSSLink .RSSLink }}
-  <link rel="alternate" href="{{ .RSSLink | default .Site.RSSLink  }}" type="application/rss+xml" title="{{ .Site.Title }}">
-  <link rel="feed" href="{{ .RSSLink | default .Site.RSSLink }}" type="application/rss+xml" title="{{ .Site.Title }}">
-  {{ end }}
+  {{ with .OutputFormats.Get "rss" -}}
+  <link rel="alternate" href="{{ .Permalink }}" type="application/rss+xml" title="{{ $.Site.Title }}">
+  <link rel="feed" href="{{ .Permalink }}" type="application/rss+xml" title="{{ $.Site.Title }}">
+  {{ end -}}
 
   {{ partial "favicons" . }}
 

--- a/themes/academic/layouts/index.json
+++ b/themes/academic/layouts/index.json
@@ -28,8 +28,8 @@
     {{/* Correct the title and URL for author profile pages. */}}
     {{- if eq .Section "author" -}}
       {{- $title = .Params.name -}}
-      {{- $dir := path.Base (path.Split .Path).Dir -}}
-      {{- with $.Site.GetPage (printf "/authors/%s" (path.Base (path.Split .Path).Dir)) -}}
+      {{- $dir := path.Base (path.Split .File.Dir).Dir -}}
+      {{- with $.Site.GetPage (printf "/authors/%s" (path.Base (path.Split .File.Dir).Dir)) -}}
         {{- $permalink = .Permalink -}}
         {{- $rel_permalink = .RelPermalink -}}
       {{- end -}}
@@ -54,7 +54,7 @@
     {{- end -}}
 
     {{- /* Add page to index. */ -}}
-    {{- $index = $index | append (dict "objectID" .UniqueID "date" .Date.UTC.Unix "publishdate" .PublishDate "lastmod" .Lastmod.UTC.Unix "expirydate" .ExpiryDate.UTC.Unix "lang" .Lang "permalink" $permalink "relpermalink" $rel_permalink "title" $title "summary" (plainify $desc) "content" .Plain "authors" $authors "kind" .Kind "type" .Type "section" .Section "tags" .Params.Tags "categories" .Params.Categories) -}}
+    {{- $index = $index | append (dict "objectID" (.RelPermalink | md5) "date" .Date.UTC.Unix "publishdate" .PublishDate "lastmod" .Lastmod.UTC.Unix "expirydate" .ExpiryDate.UTC.Unix "lang" .Lang "permalink" $permalink "relpermalink" $rel_permalink "title" $title "summary" (plainify $desc) "content" .Plain "authors" $authors "kind" .Kind "type" .Type "section" .Section "tags" .Params.Tags "categories" .Params.Categories) -}}
 
   {{- end -}}
 {{- end -}}

--- a/themes/academic/layouts/partials/docs_sidebar.html
+++ b/themes/academic/layouts/partials/docs_sidebar.html
@@ -1,5 +1,5 @@
 {{ $current_page := . }}
-{{ $menu_name := (path.Base (path.Split .Path).Dir) }}
+{{ $menu_name := .Section | default "docs" }}
 {{ with (index .Site.Menus $menu_name) }}
 {{ else }}
 {{ errorf "Please define menu items named `[menu.%s]` in your %s front matter or define `[[menu.%s]]` in `config.toml`." $menu_name .Path $menu_name }}

--- a/themes/academic/layouts/partials/header.html
+++ b/themes/academic/layouts/partials/header.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="generator" content="Source Themes Academic {{ .Site.Data.academic.version }}">
-  {{ .Hugo.Generator }}
+  {{ hugo.Generator }}
 
   {{ $scr := .Scratch }}
 
@@ -133,10 +133,10 @@
   {{ end }}
   {{ end }}
 
-  {{ if or .Site.RSSLink .RSSLink }}
-  <link rel="alternate" href="{{ .RSSLink | default .Site.RSSLink  }}" type="application/rss+xml" title="{{ .Site.Title }}">
-  <link rel="feed" href="{{ .RSSLink | default .Site.RSSLink }}" type="application/rss+xml" title="{{ .Site.Title }}">
-  {{ end }}
+  {{ with .OutputFormats.Get "rss" -}}
+  <link rel="alternate" href="{{ .Permalink }}" type="application/rss+xml" title="{{ $.Site.Title }}">
+  <link rel="feed" href="{{ .Permalink }}" type="application/rss+xml" title="{{ $.Site.Title }}">
+  {{ end -}}
 
   {{ partial "favicons" . }}
 

--- a/themes/academic/layouts/partials/navbar.html
+++ b/themes/academic/layouts/partials/navbar.html
@@ -156,7 +156,7 @@
             <ul class="dropdown-menu">
               {{ range .Translations }}
               <li class="dropdown-item my-0 py-0 mx-0 px-0">
-                <a href="{{ .RelPermalink }}"{{ if $.IsHome }} data-target="{{ .URL }}"{{ end }}>
+                <a href="{{ .RelPermalink }}"{{ if $.IsHome }} data-target="{{ .RelPermalink }}"{{ end }}>
                   <span>{{ index .Site.Data.i18n.languages .Lang }}</span>
                 </a>
               </li>

--- a/themes/academic/layouts/partials/page_links_div.html
+++ b/themes/academic/layouts/partials/page_links_div.html
@@ -6,7 +6,7 @@
 
 {{ $slug := "" }}
 {{ if eq $.File.TranslationBaseName "index" }}{{/* Check if using dir-based page bundles. */}}
-  {{ $slug = delimit (last 1 (split (substr $.Dir 0 -1) "/")) "" }}
+  {{ $slug = delimit (last 1 (split (substr $.File.Dir 0 -1) "/")) "" }}
 {{ end }}
 {{ $resource := $.Resources.GetMatch (printf "%s.pdf" $slug) }}
 {{ with $resource }}

--- a/themes/academic/layouts/partials/widget_page.html
+++ b/themes/academic/layouts/partials/widget_page.html
@@ -47,7 +47,7 @@
   {{ if in (slice "slider") $widget }}
     {{ partial $widget_path $params }}
   {{ else }}
-  <section id="{{ $st.File.TranslationBaseName }}" class="home-section {{ printf "wg-%s" (replace $widget "_" "-") }} {{if $bg.text_color_light}}dark{{end}} {{if $bg.image}}parallax{{end}} {{ with $st.Params.advanced.css_class }}{{ . }}{{ end }}" {{with $style}}style="{{. | safeCSS}}"{{end}}>
+  <section id="{{ with $st.File }}{{ .TranslationBaseName }}{{ end }}" class="home-section {{ printf "wg-%s" (replace $widget "_" "-") }} {{if $bg.text_color_light}}dark{{end}} {{if $bg.image}}parallax{{end}} {{ with $st.Params.advanced.css_class }}{{ . }}{{ end }}" {{with $style}}style="{{. | safeCSS}}"{{end}}>
     <div class="container">
       {{ partial $widget_path $params }}
     </div>

--- a/themes/academic/layouts/partials/widgets/people.html
+++ b/themes/academic/layouts/partials/widgets/people.html
@@ -26,7 +26,7 @@
   {{ $avatar := (.Resources.ByType "image").GetMatch "*avatar*" }}
   {{/* Get link to user's profile page. */}}
   {{ $link := "" }}
-  {{ with $.Site.GetPage (printf "/authors/%s" (path.Base (path.Split .Path).Dir)) }}
+  {{ with $.Site.GetPage (printf "/authors/%s" (path.Base (path.Split .File.Dir).Dir)) }}
     {{ $link = .RelPermalink }}
   {{ end }}
   <div class="col-12 col-sm-auto people-person">

--- a/themes/academic/layouts/rss.xml
+++ b/themes/academic/layouts/rss.xml
@@ -9,7 +9,7 @@
     <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
-    <atom:link href="{{.URL}}" rel="self" type="application/rss+xml" />
+    <atom:link href="{{.Permalink}}" rel="self" type="application/rss+xml" />
     {{ range first 15 (where .Data.Pages "Type" "!=" "home") }}
     <item>
       <title>{{ .Title }}</title>


### PR DESCRIPTION
- [x] The commit message follows our guidelines


* **What kind of change does this PR introduce?** 
    /kind bug

* **What this PR does / why we need it**:
Upgrades the repository to compile successfully on modern versions of Hugo (v0.123+). Previously, attempting to run `hugo server -D` on a modern compiler caused fatal crashes due to:
- Strict TOML parsing errors in legacy blog posts (e.g. `dateday = 0X`).
- An invalid markdown URL syntax in the v1.11 release blog.
- Deprecated template variables (`.Hugo.Generator`, `.RSSLink`, `.Language.ContentDir`, `.UniqueID`, `.Dir`). 

This PR patches all templates and blog posts to ensure new contributors can build the website locally.

* **Which issue(s) this PR fixes**:
Fixes #496 
<img width="1919" height="1029" alt="Screenshot 2026-05-10 150238" src="https://github.com/user-attachments/assets/9aed3ea2-8911-4b80-89ce-48ea39e55929" />

<img width="1919" height="1032" alt="Screenshot 2026-05-10 150303" src="https://github.com/user-attachments/assets/b9e4f9fd-8b82-499d-9099-b7fe51f1046b" />
