### PR TITLE
fix(theme): improve dark mode visibility for icons and logos

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -86,13 +86,12 @@ b, strong {
   margin-left: 8px;
   background-position: center;
   background-repeat: no-repeat;
-  background-size: 20px;
   transition: opacity .2s ease;
 }
 
-.header-github-link { background-image: url("/img/github.svg"); }
-.header-x-link { background-image: url("/img/x.svg"); }
-.header-slack-link { background-image: url("/img/slack.svg"); }
+.header-github-link { background-image: url("/img/github.svg"); background-size: 23px; }
+.header-x-link { background-image: url("/img/x.svg"); background-size: 18px; }
+.header-slack-link { background-image: url("/img/slack.svg"); background-size: 22px; }
 
 .header-github-link:hover,
 .header-x-link:hover,
@@ -128,4 +127,15 @@ b, strong {
 
 .theme-edit-this-page {
   display: none !important;
+}
+
+
+[data-theme="dark"] .header-github-link,
+[data-theme="dark"] .header-x-link {
+  filter: invert(1) brightness(100%);
+}
+
+[data-theme="dark"] .navbar__logo {
+
+  filter: invert(1) hue-rotate(180deg) brightness(1.1);
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines

* **What kind of change does this PR introduce?**
/kind bug
/kind design

* **What this PR does / why we need it**:
this PR fixes visibility issues for icons and logos when docs-website toggled into dark mode. previously, the dark icons blended into the dark background, making them difficult to see.

* **Which issue(s) this PR fixes**:
#506 

### old 
<img width="1919" height="446" alt="image" src="https://github.com/user-attachments/assets/fa6b1704-aa6d-4b30-9078-a2b7d1fb4ef6" />
### new
<img width="1919" height="296" alt="Screenshot 2026-05-27 223831" src="https://github.com/user-attachments/assets/4d4c5052-556f-4562-8831-919a27eb9102" />
