### PR TITLE
website: fix broken OG image and supporter links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -91,7 +91,7 @@ const config = {
   ],
 
   themeConfig: {
-    image: "img/docusaurus-social-card.jpg",
+    image: "img/landing/volcano_logo.png",
     navbar: {
       title: "",
       logo: {

--- a/src/components/Supporters/index.js
+++ b/src/components/Supporters/index.js
@@ -104,7 +104,7 @@ const supporters = [
     imgSrc: "img/landing/logo_zhongkeleinao.png",
     imgWidth: "100px",
     imgHeight: "60px",
-    url: "http://www.leinao.ai/"
+    url: "https://www.leinao.ai/"
   },
   {
     imgSrc: "img/landing/logo_bibdr.png",
@@ -122,7 +122,7 @@ const supporters = [
     imgSrc: "img/landing/logo_qiezi.png",
     imgWidth: "100px",
     imgHeight: "60px",
-    url: "https://shareit.one/"
+    url: "https://www.ushareit.com/"
   },
   {
     imgSrc: "img/landing/logo_vivo.png",


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it:**

- Point `themeConfig.image` at `img/landing/volcano_logo.png` (fixes 404 for missing `docusaurus-social-card.jpg`)
- Update leinao supporter link to HTTPS (`https://www.leinao.ai/`)
- Update SHAREit supporter link to official site (`https://www.ushareit.com/`)

**Which issue(s) this PR fixes:**

Fixes volcano-sh/website#505

**Not changed (deferred):**

- `ruitiancapital.com` and `bocloud.com.cn` — maintainer noted possible regional 504 from some networks; awaiting confirmation before changing URLs.

**Test plan:**

- [x] `npm run build` passes locally
- [x] Homepage supporter links for leinao and SHAREit use updated URLs
- [x] OG image path resolves (no 404 for configured `themeConfig.image`)