### PR TITLE
website: restore Google Analytics 4 for volcano.sh

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -110,6 +110,11 @@ const config = {
           onUntruncatedBlogPosts: "warn",
         },
 
+        gtag: {
+          trackingID: "G-GN2GSDH4JQ",
+          anonymizeIP: true,
+        },
+
         theme: {
           customCss: "./src/css/custom.css",
         },


### PR DESCRIPTION
## What kind of change does this PR introduce?

/kind documentation

## What this PR does / why we need it

Restores Google Analytics 4 on [volcano.sh](https://volcano.sh) using the Docusaurus
classic preset `gtag` option. GA4 was configured for the Hugo site in
[website#304](https://github.com/volcano-sh/website/pull/304) (measurement ID
`G-GN2GSDH4JQ`) but was not carried over during the Hugo → Docusaurus migration.

This addresses the CLOMonitor **analytics** check for the website repository as
part of the Volcano CLOMonitor improvement effort.

Part of volcano-sh/volcano#5366

## Which issue(s) this PR fixes

Part of volcano-sh/volcano#5366

## Special notes for reviewers

- Please confirm `G-GN2GSDH4JQ` is still the correct GA4 property in Google
  Analytics admin ([website#301](https://github.com/volcano-sh/website/issues/301)
  previously reported no data in GA4).
- `anonymizeIP: true` is set for consistency with prior Hugo gtag setup.
- Analytics loads only on production builds (`NODE_ENV=production`); not on
  `npm run start`.
- No new npm dependencies; uses `@docusaurus/plugin-google-gtag` from
  `preset-classic`.

## Test plan

- [x] `npm run build` succeeds
- [x] `G-GN2GSDH4JQ` present in generated `build/**/*.html`
- [ ] After merge: verify Netlify deploy and CLOMonitor analytics check on
  [clomonitor.io/projects/cncf/volcano](https://clomonitor.io/projects/cncf/volcano)