### PR TITLE
Fix: Redirect for website url 

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -8,6 +8,7 @@
 /volcano/* go-get=1 /golang/volcano.html 200
 /apis/* go-get=1 /golang/api.html 200
 
+<<<<<<< HEAD
 # ---------------------------------------------------------------------------
 # Redirect legacy (Hugo) documentation URLs to the new Docusaurus structure.
 # The old site served docs at /<locale>/docs/<slug>/ and per-version copies at
@@ -231,3 +232,13 @@
 # Legacy locale home pages.
 /en/                                                       /                                              301
 /zh/                                                       /zh-Hans/                                      301
+=======
+# Redirect old blog URL to localized English path
+# This ensures links to /blog/aiqiyi-en/ land on the current /en/blog/aiqiyi-en/
+/blog/aiqiyi-en/ /en/blog/aiqiyi-en/ 301
+/blog/aiqiyi-en /en/blog/aiqiyi-en/ 301
+
+# Ensure Chinese localized path is also covered
+/zh/blog/aiqiyi-en/ /zh-Hans/blog/aiqiyi-en/ 301
+/zh/blog/aiqiyi-en /zh-Hans/blog/aiqiyi-en/ 301
+>>>>>>> 76b9422 (fix: use /zh-Hans for Chinese blog redirect)

--- a/static/_redirects
+++ b/static/_redirects
@@ -234,9 +234,9 @@
 /zh/                                                       /zh-Hans/                                      301
 =======
 # Redirect old blog URL to localized English path
-# This ensures links to /blog/aiqiyi-en/ land on the current /en/blog/aiqiyi-en/
-/blog/aiqiyi-en/ /en/blog/aiqiyi-en/ 301
-/blog/aiqiyi-en /en/blog/aiqiyi-en/ 301
+# The default English locale is served at the root. Keep /blog/aiqiyi-en/ as the final target,
+# and normalize the non-trailing slash URL to the trailing slash version.
+/blog/aiqiyi-en /blog/aiqiyi-en/ 301
 
 # Ensure Chinese localized path is also covered
 /zh/blog/aiqiyi-en/ /zh-Hans/blog/aiqiyi-en/ 301


### PR DESCRIPTION
Keeps the existing English redirect from /blog/aiqiyi-en to /en/blog/aiqiyi-en/ intact
also done for other CN language.
#522 