### PR TITLE
docs: update CLI docs to note vcctl is not in release packages

### DIFF
--- a/docs/CLI/Commandline.md
+++ b/docs/CLI/Commandline.md
@@ -7,51 +7,93 @@ title: CLI
 # CLI 
 
 ## Introduction
-A Command Line Interface (CLI) is provided for you to manage resources.
 
-## Configuration
+A Command Line Interface (CLI) tool called `vcctl` is provided for you to manage Volcano resources such as jobs and queues.
 
-1. You can obtain the latest executable file by cloning the code from GitHub and running the following command in the root directory of the project:
+## Installation
 
-```bash
-make vcctl
-``` 
+### Prerequisites
 
-2. Copy the executable file to `$PATH`. You then can execute it anywhere.
+- [Go](https://golang.org/doc/install) (version matching the project's `go.mod`)
+- [Git](https://git-scm.com/)
 
-## Command Line List
+### Building from source
+
+1. Clone the Volcano repository:
+
+   ```bash
+   git clone https://github.com/volcano-sh/volcano.git
+   cd volcano
+   ```
+   
+
+2. Build the `vcctl` binary:
+
+   ```bash
+   make vcctl
+   ```
+
+3. The binary will be generated in the `_output/bin/` directory. Copy it to a directory in your `$PATH`:
+
+   ```bash
+   sudo cp _output/bin/vcctl /usr/local/bin/
+   ```
+
+4. Verify the installation:
+
+   ```bash
+   vcctl --help
+   ```
+
+## Command Line Reference
 
 ### Listing all jobs
+
+```bash
 vcctl job list
 ```
-vcctl job list
+
+Example output:
+
+```
 Name    Creation       Phase       JobType     Replicas    Min   Pending   Running   Succeeded   Failed    Unknown     RetryCount
 job-1   2020-09-01     Running     Batch       1           1     0         1         0           0         0           0        
 ```
 
 ### Deleting a specific job
-vcctl job delete --name job-name [--namespace job-namespace]
-
 
 ```bash
-vcctl delete job --name job-1 --namespace default
+vcctl job delete --name job-name [--namespace job-namespace]
+```
+
+Example:
+
+```bash
+vcctl job delete --name job-1 --namespace default
 # Output: delete job job-1 successfully
 ```
 
 ### Suspending a job
 
+```bash
 vcctl job suspend --name job-name [--namespace job-namespace]
+```
 
-
+Example:
 
 ```bash
 vcctl job suspend --name job-1 --namespace default
 ```
 
-### Resuming a job (opposite to "vcctl job suspend")
+### Resuming a job
 
+Resume a suspended job (opposite of `vcctl job suspend`):
+
+```bash
 vcctl job resume --name job-name [--namespace job-namespace]
+```
 
+Example:
 
 ```bash
 vcctl job resume --name job-1 --namespace default
@@ -59,10 +101,13 @@ vcctl job resume --name job-1 --namespace default
 
 ### Running a job
 
+```bash
 vcctl job run --name job-name [--namespace job-namespace]
+```
 
+Example:
 
-```html
+```bash
 vcctl job run --name job-1 --namespace default
 ```
 
@@ -73,3 +118,4 @@ For more information about Volcano command lines, run the following commands:
 ```bash
 vcctl -h
 vcctl [command] -h
+```

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/CLI/Commandline.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/CLI/Commandline.md
@@ -1,54 +1,119 @@
 ---
+id: cli
 title: CLI
 ---
-### 简介
-Volcano提供了命令行工具用于管理资源。
-## 配置
 
-1. 您可以自己从 github 上克隆代码并在项目的根目录下执行以下命令制作最新的可执行文件：
-```shell
-# make vcctl
+# CLI
+
+## 简介
+
+Volcano提供了一个名为 `vcctl` 的命令行工具用于管理资源，如作业（jobs）和队列（queues）。
+
+## 安装
+
+### 先决条件
+
+- [Go](https://golang.org/doc/install) (版本需与项目的 `go.mod` 匹配)
+- [Git](https://git-scm.com/)
+
+### 从源码构建
+
+1. 克隆 Volcano 代码库：
+
+   ```bash
+   git clone https://github.com/volcano-sh/volcano.git
+   cd volcano
+   ```
+
+2. 构建 `vcctl` 二进制文件：
+
+   ```bash
+   make vcctl
+   ```
+
+3. 二进制文件将生成在 `_output/bin/` 目录下。将其复制到您的 `$PATH` 目录中：
+
+   ```bash
+   sudo cp _output/bin/vcctl /usr/local/bin/
+   ```
+
+4. 验证安装：
+
+   ```bash
+   vcctl --help
+   ```
+
+## 命令行参考
+
+### 列举所有的 Job
+
+```bash
+vcctl job list
 ```
-2. 将可执行文件拷贝到$PATH下以便您能在任何地方执行它。
 
-## 命令行列表
-### 列举所有的Job
+输出示例：
 
-```shell
-# vcctl job list
+```
 Name    Creation       Phase       JobType     Replicas    Min   Pending   Running   Succeeded   Failed    Unknown     RetryCount
 job-1   2020-09-01     Running     Batch       1           1     0         1         0           0         0           0
 ```
 
-### 删除指定的Job
+### 删除指定的 Job
 
-```shell
-# vcctl delete job --name job-1 --namespaces default
-delete job job-1 successfully
+```bash
+vcctl job delete --name job-name [--namespace job-namespace]
 ```
 
-### 中止一个Job
+示例：
 
-```shell
-# vcctl job suspend --name job-1 --namespace default
+```bash
+vcctl job delete --name job-1 --namespace default
+# Output: delete job job-1 successfully
 ```
 
-### 消费一个Job (与"vcctl job suspend"相反)
+### 挂起（中止）一个 Job
 
-``` shell
-# vcctl job resume --name job-1 --namespace default
+```bash
+vcctl job suspend --name job-name [--namespace job-namespace]
 ```
 
-### 运行一个Job
+示例：
 
-```shell
-# vcctl job run --name job-1 --namespace default
+```bash
+vcctl job suspend --name job-1 --namespace default
+```
+
+### 恢复一个 Job
+
+恢复一个被挂起的 Job (与 `vcctl job suspend` 相反)：
+
+```bash
+vcctl job resume --name job-name [--namespace job-namespace]
+```
+
+示例：
+
+```bash
+vcctl job resume --name job-1 --namespace default
+```
+
+### 运行一个 Job
+
+```bash
+vcctl job run --name job-name [--namespace job-namespace]
+```
+
+示例：
+
+```bash
+vcctl job run --name job-1 --namespace default
 ```
 
 ## 说明事项
+
 如需获取更多命令行详情请按如下操作:
 
-```shell
-# vcctl -h
-# vcctl [command] -h
+```bash
+vcctl -h
+vcctl [command] -h
 ```


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines

* **What kind of change does this PR introduce?**
/kind documentation

* **What this PR does / why we need it**:
Updates the CLI documentation to clearly state that `vcctl` is not included
in official Volcano release packages and must be built from source.

Also fixes several Markdown formatting issues:
- Added missing code fences around bare command examples
- Fixed wrong language tag (`html` → `bash`)
- Added proper installation prerequisites (Go, Git)
- Added complete build-from-source workflow
- Fixed abrupt file ending

* **Which issue(s) this PR fixes**:
Fixes #123
