### PR TITLE
docs(capacity): document ancestor reclaim level

### DIFF
--- a/docs/KeyFeatures/HierarchicalQueue.md
+++ b/docs/KeyFeatures/HierarchicalQueue.md
@@ -39,6 +39,42 @@ data:
       - name: nodeorder
 ```
 
+### Configure Ancestor Reclaim Scope
+
+`ancestorReclaimLevel` is configured as an argument of the `capacity` plugin. It is only meaningful when hierarchical queue mode is enabled with `enableHierarchy: true` and the scheduler has the `reclaim` action enabled.
+
+```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: volcano-scheduler-configmap
+  namespace: volcano-system
+data:
+  volcano-scheduler.conf: |
+    actions: "allocate, preempt, reclaim"
+    tiers:
+    - plugins:
+      - name: priority
+      - name: gang
+        enablePreemptable: false
+    - plugins:
+      - name: drf
+        enablePreemptable: false
+      - name: predicates
+      - name: capacity
+        enableHierarchy: true
+        arguments:
+          ancestorReclaimLevel: 1
+      - name: nodeorder
+```
+
+The value controls how many ancestor levels are checked when Volcano decides whether a running workload from another queue can be reclaimed:
+
+- `0`: keep the default behavior. Volcano does not add ancestor-level reclaim restrictions.
+- `1`: add parent-level deserved-resource checks for cross-parent reclaim.
+- `2`: add grandparent-level checks when the queue topology reaches that level.
+- `N`: continue the same pattern for deeper queue trees.
+
 ### Building Hierarchical Queues
 A new `parent` field has been added to the Queue spec to specify the parent queue:
 
@@ -135,3 +171,117 @@ spec:
 When cluster resources are insufficient for pod requirement, pod's resources can be reclaimed. For pods in different queues, they will first reclaim pods in sibling queues (if the allocated resources of the sibling queue exceed the `deserved` value). If the resources in sibling queues are still insufficient to meet the pod's requirements, the hierarchical structure of the queues (i.e., ancestor queues) will be traversed upward to find sufficient resources. For example, if job-a and job-c are submitted first and the cluster resources are insufficient for job-b, job-b will first reclaim job-a. If reclaiming job-a does not meet the resource requirements, job-c will then be considered for reclaiming.
 
 Note that in the current version, users can only submit jobs to **leaf queues**. If tasks have already been submitted to a parent queue, child queues cannot be created under that queue. This ensures effective management of resources and tasks across different levels in the queue hierarchy. Additionally, the sum of the `deserved`/`guarantee` values of child queues cannot exceed the `deserved`/`guarantee` values configured for the parent queue. Each child queue's `capability` values cannot exceed the `capability` limits of the parent queue. If a queue does not specify the `capability` value for a certain resource dimension, it will inherit the `capability` from its parent queue. If the parent queue and all ancestor queues do not specify it, the value will finally inherit from the root queue. By default, the root queue's `capability` is set to the total available resources of that dimension in the cluster.
+
+### Understanding `ancestorReclaimLevel`
+
+Hierarchical queues allow one part of the queue tree to use unused `deserved` resources from another part of the queue tree. When a queue later has pending work, reclaim can give those borrowed resources back from a reclaimable queue that is over its own `deserved` resources.
+
+`ancestorReclaimLevel` controls how much of the hierarchy must be considered before a queue is treated as a valid reclaim victim. This is useful for any queue tree that encodes ownership, quota boundaries, workload classes, accelerator pools, environments, cost centers, tenants, or any other resource-sharing model.
+
+#### Scenario 1: parent-level reclaim is allowed
+
+In this example, `queue-b` is over its own `deserved` resources and its parent `parent-b` is also over its `deserved` resources. `queue-a` has a pending pod that cannot be scheduled without reclaim.
+
+```mermaid
+graph TD
+  R[root]
+  PA[parent-a<br/>deserved: a100=1<br/>allocated: a100=0]
+  QA[queue-a<br/>deserved: a100=1<br/>pending: p-reclaimer a100=1]
+  PB[parent-b<br/>deserved: a100=3<br/>allocated: a100=4]
+  QB[queue-b<br/>deserved: a100=1<br/>allocated: a100=4<br/>running: p1 a100=1, p2 a100=1, p3 a100=1, p4 a100=1]
+  R --> PA
+  PA --> QA
+  R --> PB
+  PB --> QB
+```
+
+With `ancestorReclaimLevel: 1`, Volcano checks the leaf queue and then the parent level. Because `queue-b` and `parent-b` are both over their relevant `deserved` resources, one running pod from `queue-b` can be reclaimed and the pending pod in `queue-a` can be pipelined.
+
+#### Scenario 2: parent-level reclaim is blocked
+
+Here the leaf queue `queue-b` is over its own `deserved` resources, but its parent is still within its share. That means the parent branch is not borrowing more than it should at the level being protected.
+
+```mermaid
+graph TD
+  R[root]
+  PA[parent-a<br/>deserved: a100=1<br/>allocated: a100=0]
+  QA[queue-a<br/>deserved: a100=1<br/>pending: p-reclaimer a100=1]
+  PB[parent-b<br/>deserved: a100=4<br/>allocated: a100=2]
+  QB[queue-b<br/>deserved: a100=1<br/>allocated: a100=2<br/>running: p1 a100=1, p2 a100=1]
+  R --> PA
+  PA --> QA
+  R --> PB
+  PB --> QB
+```
+
+With `ancestorReclaimLevel: 1`, reclaim from `queue-b` is blocked. The leaf queue is over deserved, but the protected parent-level check fails because `parent-b` is not over deserved.
+
+#### Scenario 3: level 0 keeps the previous permissive behavior
+
+Using the same topology as Scenario 2, `ancestorReclaimLevel: 0` does not add the parent-level gate. Volcano keeps the previous behavior and relies on the existing reclaim checks. If `queue-b` is reclaimable and over its leaf `deserved` resources, the pending pod in `queue-a` can reclaim from `queue-b` even though `parent-b` is not over deserved.
+
+This is the compatibility setting for clusters that already rely on the existing hierarchical reclaim behavior.
+
+#### Scenario 4: grandparent-level checks protect deeper trees
+
+For deeper queue trees, `ancestorReclaimLevel: 2` also evaluates the grandparent level. This is useful when reclaim should respect a boundary above the direct parent.
+
+```mermaid
+graph TD
+  R[root]
+  GA[group-a<br/>deserved: cpu=2, memory=2Gi<br/>allocated: cpu=0, memory=0]
+  PA[parent-a<br/>deserved: cpu=2, memory=2Gi<br/>allocated: cpu=0, memory=0]
+  QA[queue-a<br/>deserved: cpu=2, memory=2Gi<br/>pending: p-reclaimer cpu=2, memory=2Gi]
+  GB[group-b<br/>deserved: cpu=3, memory=3Gi<br/>allocated: cpu=2, memory=2Gi]
+  PB[parent-b<br/>deserved: cpu=1, memory=1Gi<br/>allocated: cpu=2, memory=2Gi]
+  QB[queue-b<br/>deserved: cpu=1, memory=1Gi<br/>allocated: cpu=2, memory=2Gi<br/>running: p-victim cpu=2, memory=2Gi]
+  R --> GA
+  GA --> PA
+  PA --> QA
+  R --> GB
+  GB --> PB
+  PB --> QB
+```
+
+With `ancestorReclaimLevel: 1`, reclaim can pass because the parent-level check for `parent-b` passes. With `ancestorReclaimLevel: 2`, reclaim is blocked because the grandparent-level check for `group-b` fails: `group-b` is not over its `deserved` resources. The running pod in `queue-b` is therefore not a valid reclaim victim for this pending pod.
+
+#### Scenario 5: shared ancestors do not create an extra boundary without a reclaimer signal
+
+For sibling queues, both queues already share the direct parent. The parent is not a boundary between different branches.
+
+```mermaid
+graph TD
+  R[root]
+  P[parent<br/>deserved: cpu=4, memory=4Gi]
+  QA[queue-a<br/>deserved: unset<br/>pending: p-reclaimer cpu=2, memory=2Gi]
+  QB[queue-b<br/>deserved: unset<br/>running: p-victim cpu=2, memory=2Gi]
+  R --> P
+  P --> QA
+  P --> QB
+```
+
+In this case, `ancestorReclaimLevel: 1` does not make the shared parent an additional reclaim gate. However, `queue-a` also has no relevant `deserved` value for the pending pod's requested resources, so the reclaimer queue has no leaf-level deserved signal for reclaim. Volcano can block reclaim to avoid evicting a sibling workload when the pending workload is not tied to a deserved share.
+
+#### Scenario 6: sibling reclaim is allowed when the reclaimer has a deserved signal
+
+This example uses the same shared-parent topology as Scenario 5, but `queue-a` now has a `deserved` value that matches the pending pod's requested resources.
+
+```mermaid
+graph TD
+  R[root]
+  P[parent<br/>deserved: cpu=4, memory=4Gi]
+  QA[queue-a<br/>deserved: cpu=2, memory=2Gi<br/>pending: p-reclaimer cpu=2, memory=2Gi]
+  QB[queue-b<br/>deserved: unset<br/>running: p-victim cpu=2, memory=2Gi]
+  R --> P
+  P --> QA
+  P --> QB
+```
+
+With `ancestorReclaimLevel: 1`, the shared parent still does not add another boundary between the sibling queues. Because the reclaimer queue has a relevant `deserved` signal for the pending pod, Volcano can reclaim the running pod from `queue-b` and pipeline the pending pod in `queue-a`.
+
+#### Choosing a value
+
+- Use `0` when you want compatibility with the previous reclaim behavior and do not need ancestor-level restrictions.
+- Use `1` when the direct parent should be the first protected boundary for cross-parent reclaim.
+- Use `2` or higher when the queue hierarchy has deeper quota boundaries and reclaim should respect those higher levels too.
+- Configure `deserved` on every ancestor level that should participate in reclaim decisions for the relevant resource. Without a relevant `deserved` value, an ancestor cannot provide a meaningful over-quota signal for that resource.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -6,9 +6,9 @@ const config = {
   title: "Volcano",
   tagline: "Cloud native batch scheduling system",
 
-
   future: {
     v4: true,
+    faster: false,
   },
 
   url: "https://volcano.sh",
@@ -45,7 +45,12 @@ const config = {
   projectName: "website",
 
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "throw",
+  markdown: {
+    format: "detect",
+    hooks: {
+      onBrokenMarkdownLinks: "throw",
+    },
+  },
 
   i18n: {
     defaultLocale: "en",
@@ -85,7 +90,7 @@ const config = {
       "classic",
       {
         docs: {
-          sidebarPath: require.resolve('./sidebar.js'),
+          sidebarPath: require.resolve("./sidebar.js"),
           showLastUpdateTime: true,
           showLastUpdateAuthor: false,
           editUrl: "https://github.com/volcano-sh/website/tree/master/",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -47,10 +47,13 @@ const config = {
   onBrokenLinks: "throw",
   markdown: {
     format: "detect",
+    mermaid: true,
     hooks: {
       onBrokenMarkdownLinks: "throw",
     },
   },
+
+  themes: ["@docusaurus/theme-mermaid"],
 
   i18n: {
     defaultLocale: "en",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "docs-site",
       "version": "0.0.0",
       "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/preset-classic": "3.9.2",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/preset-classic": "3.10.1",
         "@easyops-cn/docusaurus-search-local": "^0.55.0",
         "@iarna/toml": "^2.2.5",
         "@mdx-js/react": "^3.0.0",
@@ -22,54 +22,54 @@
         "react-dom": "^19.0.0"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "3.9.2",
-        "@docusaurus/types": "3.9.2"
+        "@docusaurus/module-type-aliases": "3.10.1",
+        "@docusaurus/types": "3.10.1"
       },
       "engines": {
         "node": ">=20.0"
       }
     },
     "node_modules/@algolia/abtesting": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.16.2.tgz",
-      "integrity": "sha512-n9s6bEV6imdtIEd+BGP7WkA4pEZ5YTdgQ05JQhHwWawHg3hyjpNwC0TShGz6zWhv+jfLDGA/6FFNbySFS0P9cw==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.21.0.tgz",
+      "integrity": "sha512-kGvHfBa9oQCvZh0YXeguSToBD9GNJ+gzUZQ9KPTg+KSsM36obYcsKPoX0NnlJtPflHXu7RkMaIi44xs9meR6Zw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.2.tgz",
-      "integrity": "sha512-mKv7RyuAzXvwmq+0XRK8HqZXt9iZ5Kkm2huLjgn5JoCPtDy+oh9yxUMfDDaVCw0oyzZ1isdJBc7l9nuCyyR7Nw==",
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.8.tgz",
+      "integrity": "sha512-3YEorYg44niXcm7gkft3nXYItHd44e8tmh4D33CTszPgP0QWkaLEaFywiNyJBo7UL/mqObA/G9RYuU7R8tN1IA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-plugin-algolia-insights": "1.19.2",
-        "@algolia/autocomplete-shared": "1.19.2"
+        "@algolia/autocomplete-plugin-algolia-insights": "1.19.8",
+        "@algolia/autocomplete-shared": "1.19.8"
       }
     },
     "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.2.tgz",
-      "integrity": "sha512-TjxbcC/r4vwmnZaPwrHtkXNeqvlpdyR+oR9Wi2XyfORkiGkLTVhX2j+O9SaCCINbKoDfc+c2PB8NjfOnz7+oKg==",
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.8.tgz",
+      "integrity": "sha512-ZvJWO8ZZJDpc1LNM2TTBdmQsZBLMR4rU5iNR2OYvEeFBiaf/0ESnRSSLQbryarJY4SVxtoz6A2ZtDMNM+iQEAA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.19.2"
+        "@algolia/autocomplete-shared": "1.19.8"
       },
       "peerDependencies": {
         "search-insights": ">= 1 < 3"
       }
     },
     "node_modules/@algolia/autocomplete-shared": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.2.tgz",
-      "integrity": "sha512-jEazxZTVD2nLrC+wYlVHQgpBoBB5KPStrJxLzsIFl6Kqd1AlG9sIAGl39V5tECLpIQzB3Qa2T6ZPJ1ChkwMK/w==",
+      "version": "1.19.8",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.8.tgz",
+      "integrity": "sha512-h5hf2t8ejF6vlOgvLaZzQbWs5SyH2z4PAWygNAvvD/2RI29hdQ54ldUGwqVuj9Srs+n8XUKTPUqb7fvhBhQrnQ==",
       "license": "MIT",
       "peerDependencies": {
         "@algolia/client-search": ">= 4.9.1 < 6",
@@ -77,99 +77,99 @@
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.50.2.tgz",
-      "integrity": "sha512-52iq0vHy1sphgnwoZyx5PmbEt8hsh+m7jD123LmBs6qy4GK7LbYZIeKd+nSnSipN2zvKRZ2zScS6h9PW3J7SXg==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.55.0.tgz",
+      "integrity": "sha512-Zt2GjIm7vsaf7K23tk5JmtcVNc38G9p0C2L2Lrm06miyLE/NL2etHtHInvuLc1DjxTp7Y2nId4X/tzwo372K8Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.50.2.tgz",
-      "integrity": "sha512-WpPIUg+cSG2aPUG0gS8Ko9DwRgbRPUZxJkolhL2aCsmSlcEEZT65dILrfg5ovcxtx0Kvr+xtBVsTMtsQWRtPDQ==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.55.0.tgz",
+      "integrity": "sha512-7BueMuWYg/KBA2EX9zsQ+3OAleEyrJcB+SV5Al/9pLjMQq5mXB/8M5HaUPqZwN812g5kLzj9j43VThlZgWq0hg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.50.2.tgz",
-      "integrity": "sha512-Gj2MgtArGcsr82kIqRlo6/dCAFjrs2gLByEqyRENuT7ugrSMFuqg1vDzeBjRL1t3EJEJCFtT0PLX3gB8A6Hq4Q==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.55.0.tgz",
+      "integrity": "sha512-pJZIyhvUrs+B7c5Lw0iP5yP/NsqJMda7pKRYbfG4KtfGIVSMcAalZhdqL5UX8Z9DOC4KxO9tKV5RDeVjZU0VfQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.50.2.tgz",
-      "integrity": "sha512-CUqoid5jDpmrc0oK3/xuZXFt6kwT0P9Lw7/nsM14YTr6puvmi+OUKmURpmebQF22S2vCG8L1DAoXXujxQUi/ug==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.55.0.tgz",
+      "integrity": "sha512-RydkKDhx0GWTYuw0ndTXHGM8hD8hgwftKE65FfnJZb5bPc9CevOqv3qNPUQiviAwkqT9hQNH31uDGeV3yZkgfA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.50.2.tgz",
-      "integrity": "sha512-AndZWFoc0gbP5901OeQJ73BazgGgSGiBEba4ohdoJuZwHTO2Gio8Q4L1VLmytMBYcviVigB0iICToMvEJxI4ug==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.55.0.tgz",
+      "integrity": "sha512-XiS7gdFq/COWiwdWXZ8+RHuewfEo03TkGESk44zU8zTc/Z6R8fm4DNmV52swJKkeB2N9iC7NKpgpM22OOkcgTw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.50.2.tgz",
-      "integrity": "sha512-NWoL+psEkz5dIzweaByVXuEB45wS8/rk0E0AhMMnaVJdVs7TcACPH2/OURm+N0xRDITkTHqCna823rd6Uqntdg==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.55.0.tgz",
+      "integrity": "sha512-LBEJ/q+hn1nJ0aYg5IcWgLNCPjWHTahWmpHNx1qUZMho+9CyWM6LaEnhac45UHjQm/j0m374HP685VrpL133lA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.50.2.tgz",
-      "integrity": "sha512-ypSboUJ3XJoQz5DeDo82hCnrRuwq3q9ZdFhVKAik9TnZh1DvLqoQsrbBjXg7C7zQOtV/Qbge/HmyoV6V5L7MhQ==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.55.0.tgz",
+      "integrity": "sha512-2/9jUXKH4IcdU5qxH6cbDH46ZBe46G7xr+MrcHwgEXZcUfdAvUgLSH53MAWuMgxvw0G5yoqiWMifHc62Os0fiQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -182,81 +182,81 @@
       "license": "MIT"
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.50.2.tgz",
-      "integrity": "sha512-VlR2FRXLw2bCB94SQo6zxg/Qi+547aOji6Pb+dKE7h1DMCCY317St+OpjpmgzE+bT2O9ALIc0V4nVIBOd7Gy+Q==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.55.0.tgz",
+      "integrity": "sha512-80tKsQgxXWo+jK0v4YGCHqyTEXawhAKYyr3kOdN51ElfRqUFjZNPVhZk6vRiqSqXfvrH85ytacT3cbJR6+qolA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.50.2.tgz",
-      "integrity": "sha512-Cmvfp2+qopzQt8OilU97rhLhosq7ZrB6uieok3EwFUqG/aalPg6DgfCmu0yJMrYe+KMC1qRVt1MTRAUwLknUMQ==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.55.0.tgz",
+      "integrity": "sha512-4UjmAL8ywGW4rCfK6Qmgw3wIjbrO2wl2s4Eq56JTiN40L2t0XTv0HZkYAmr6nfeiXO0he/2crvZRX6SATSepag==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.50.2.tgz",
-      "integrity": "sha512-jrkuyKoOM7dFWQ/6Y4hQAse2SC3L/RldG6GnPjMvAj65h+7Ubb51S0pKk4ofSStF0xm4LCNe0C4T6XX4nOFDiQ==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.55.0.tgz",
+      "integrity": "sha512-LMpJPtIkfDsHIx5Ga+baNr22ntYbY+e2wT7MSIc/FjAnu9wnBFhx1H/GfhmP/c5/IvbThDX+3ilxPRjSfCI8aA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.50.2.tgz",
-      "integrity": "sha512-4107YLJqCudPiBUlwnk6oTSUVwU7ab+qL1SfQGEDYI8DZH5gsf1ekPt9JykXRKYXf2IfouFL5GiCY/PHTFIjYw==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.55.0.tgz",
+      "integrity": "sha512-tDymJ7nFOAoUuecma3usK6o94dp8m4HYFDGh4ByYQXWkv14cpmDn+nWdylmcZO0Qvco107vqDo4+Anksnl8w1Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2"
+        "@algolia/client-common": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.50.2.tgz",
-      "integrity": "sha512-vOrd3MQpLgmf6wXAueTuZ/cA0W4uRwIHHaxNy3h+a6YcNn6bCV/gFdZuv3F13v593zRU2k5R75NmvRWLenvMrw==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.55.0.tgz",
+      "integrity": "sha512-6IDSB5o5dkDPQ4LdOW0Yuw/qy5MdWlO2xDHgPVZgW4YDjbxvnX5PAiV7/WWZdWyVObScZZnnHpPbiqfYs/zBLg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2"
+        "@algolia/client-common": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.50.2.tgz",
-      "integrity": "sha512-Mu9BFtgzGqDUy5Bcs2nMyoILIFSN13GKQaklKAFIsd0K3/9CpNyfeBc+/+Qs6mFZLlxG9qzullO7h+bjcTBuGQ==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.55.0.tgz",
+      "integrity": "sha512-Yyyne4l//vDSdg4MhYJkaVne+KEPi833eCj3/T/87ernTwrvP6j9biXXZELsN8sLI/f2ndV/vugDIy2jdJQB6g==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.50.2"
+        "@algolia/client-common": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -514,9 +514,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1438,12 +1438,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-react-constant-elements": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.27.1.tgz",
-      "integrity": "sha512-edoidOjl/ZxvYo4lSBOQGDSyToYVkTAwyVoa2tkuYTSmjrB1+uAedoL5iROVLXkxH+vRgA7uP4tMg2pUJpZ3Ug==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.29.7.tgz",
+      "integrity": "sha512-J0wGhKan+rIiE2OhfhRptySLrJ6SjQYM6b6N1FMlhyhCcw1Mig8vQjWchyB+bgHGDvaWo6Diu6CLRMra2uMtmg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1914,18 +1914,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/runtime-corejs3": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz",
-      "integrity": "sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==",
-      "license": "MIT",
-      "dependencies": {
-        "core-js-pure": "^3.48.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3311,9 +3299,9 @@
       }
     },
     "node_modules/@docsearch/core": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.6.2.tgz",
-      "integrity": "sha512-/S0e6Dj7Zcm8m9Rru49YEX49dhU11be68c+S/BCyN8zQsTTgkKzXlhRbVL5mV6lOLC2+ZRRryaTdcm070Ug2oA==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.6.3.tgz",
+      "integrity": "sha512-rUOujwIpxJRgD7+kicVsI3D5sqBvdiRTquzWBpTEXZs8ZXfGbfzpus5HqumaNYTppN2HvH8E2yNuRwYdHJeOlA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": ">= 16.8.0 < 20.0.0",
@@ -3333,20 +3321,20 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.6.2.tgz",
-      "integrity": "sha512-fH/cn8BjEEdM2nJdjNMHIvOVYupG6AIDtFVDgIZrNzdCSj4KXr9kd+hsehqsNGYjpUjObeKYKvgy/IwCb1jZYQ==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.6.3.tgz",
+      "integrity": "sha512-nlOwcXcsNAptQl4vlL4MA78qNJKO0Qlds5GuBjCoePgkebTXLSf8Qt1oyZ3YBshYupKXG9VRGEsk1zr23d+bzQ==",
       "license": "MIT"
     },
     "node_modules/@docsearch/react": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.6.2.tgz",
-      "integrity": "sha512-/BbtGFtqVOGwZx0dw/UfhN/0/DmMQYnulY4iv0tPRhC2JCXv0ka/+izwt3Jzo1ZxXS/2eMvv9zHsBJOK1I9f/w==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.6.3.tgz",
+      "integrity": "sha512-Bg2wdDsoQVlNCcEKuEJAU04tvHCqgx8rIu+uIoM4pRtcx3TBKJuXutJik3LTA8LRc9YEyHkrYUrmcC0D7BYf+g==",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-core": "1.19.2",
-        "@docsearch/core": "4.6.2",
-        "@docsearch/css": "4.6.2"
+        "@docsearch/core": "4.6.3",
+        "@docsearch/css": "4.6.3"
       },
       "peerDependencies": {
         "@types/react": ">= 16.8.0 < 20.0.0",
@@ -3369,10 +3357,42 @@
         }
       }
     },
+    "node_modules/@docsearch/react/node_modules/@algolia/autocomplete-core": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.2.tgz",
+      "integrity": "sha512-mKv7RyuAzXvwmq+0XRK8HqZXt9iZ5Kkm2huLjgn5JoCPtDy+oh9yxUMfDDaVCw0oyzZ1isdJBc7l9nuCyyR7Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.19.2",
+        "@algolia/autocomplete-shared": "1.19.2"
+      }
+    },
+    "node_modules/@docsearch/react/node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.2.tgz",
+      "integrity": "sha512-TjxbcC/r4vwmnZaPwrHtkXNeqvlpdyR+oR9Wi2XyfORkiGkLTVhX2j+O9SaCCINbKoDfc+c2PB8NjfOnz7+oKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.19.2"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@docsearch/react/node_modules/@algolia/autocomplete-shared": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.2.tgz",
+      "integrity": "sha512-jEazxZTVD2nLrC+wYlVHQgpBoBB5KPStrJxLzsIFl6Kqd1AlG9sIAGl39V5tECLpIQzB3Qa2T6ZPJ1ChkwMK/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
     "node_modules/@docusaurus/babel": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.9.2.tgz",
-      "integrity": "sha512-GEANdi/SgER+L7Japs25YiGil/AUDnFFHaCGPBbundxoWtCkA2lmy7/tFmgED4y1htAy6Oi4wkJEQdGssnw9MA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.10.1.tgz",
+      "integrity": "sha512-DZzFO1K3v/GoEt1fx1DiYHF4en+PuhtQf1AkQJa5zu3CoeKSpr5cpQRUlz3jr0m44wyzmSXu9bVpfir+N4+8bg==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
@@ -3383,10 +3403,9 @@
         "@babel/preset-react": "^7.25.9",
         "@babel/preset-typescript": "^7.25.9",
         "@babel/runtime": "^7.25.9",
-        "@babel/runtime-corejs3": "^7.25.9",
         "@babel/traverse": "^7.25.9",
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -3396,17 +3415,17 @@
       }
     },
     "node_modules/@docusaurus/bundler": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.9.2.tgz",
-      "integrity": "sha512-ZOVi6GYgTcsZcUzjblpzk3wH1Fya2VNpd5jtHoCCFcJlMQ1EYXZetfAnRHLcyiFeBABaI1ltTYbOBtH/gahGVA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.10.1.tgz",
+      "integrity": "sha512-HIqQPvbqnnQRe4NsBd1774KRarjXqS6wHsWELtyuSs1gCfvixJO2jUGH/OEBtr1Gvzpw+ze5CjGMvSJ8UE1KUw==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
-        "@docusaurus/babel": "3.9.2",
-        "@docusaurus/cssnano-preset": "3.9.2",
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
+        "@docusaurus/babel": "3.10.1",
+        "@docusaurus/cssnano-preset": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
         "babel-loader": "^9.2.1",
         "clean-css": "^5.3.3",
         "copy-webpack-plugin": "^11.0.0",
@@ -3424,7 +3443,7 @@
         "tslib": "^2.6.0",
         "url-loader": "^4.1.1",
         "webpack": "^5.95.0",
-        "webpackbar": "^6.0.1"
+        "webpackbar": "^7.0.0"
       },
       "engines": {
         "node": ">=20.0"
@@ -3434,333 +3453,50 @@
       },
       "peerDependenciesMeta": {
         "@docusaurus/faster": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@docusaurus/bundler/node_modules/webpackbar": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-7.0.0.tgz",
+      "integrity": "sha512-aS9soqSO2iCHgqHoCrj4LbfGQUboDCYJPSFOAchEK+9psIjNrfSWW4Y0YEz67MKURNvMmfo0ycOg9d/+OOf9/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansis": "^3.2.0",
+        "consola": "^3.2.3",
+        "pretty-time": "^1.1.0",
+        "std-env": "^3.7.0"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "@rspack/core": "*",
+        "webpack": "3 || 4 || 5"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "webpack": {
           "optional": true
         }
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.9.2.tgz",
-      "integrity": "sha512-HbjwKeC+pHUFBfLMNzuSjqFE/58+rLVKmOU3lxQrpsxLBOGosYco/Q0GduBb0/jEMRiyEqjNT/01rRdOMWq5pw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.10.1.tgz",
+      "integrity": "sha512-3pf2fXXw0eVk8WnC3T4LIigRDupcpvngpKo9Vy7mYyBhuddc0klDUuZAIfzMoK6z05pdlk6EFC/vBSX43+1O5w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.9.2",
-        "@docusaurus/bundler": "3.9.2",
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/mdx-loader": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-common": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "core-js": "^3.31.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "execa": "5.1.1",
-        "fs-extra": "^11.1.1",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.6.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "open": "^8.4.0",
-        "p-map": "^4.0.0",
-        "prompts": "^2.4.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.6",
-        "tinypool": "^1.0.2",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "webpack": "^5.95.0",
-        "webpack-bundle-analyzer": "^4.10.2",
-        "webpack-dev-server": "^5.2.2",
-        "webpack-merge": "^6.0.1"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=20.0"
-      },
-      "peerDependencies": {
-        "@mdx-js/react": "^3.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.9.2.tgz",
-      "integrity": "sha512-8gBKup94aGttRduABsj7bpPFTX7kbwu+xh3K9NMCF5K4bWBqTFYW+REKHF6iBVDHRJ4grZdIPbvkiHd/XNKRMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "cssnano-preset-advanced": "^6.1.2",
-        "postcss": "^8.5.4",
-        "postcss-sort-media-queries": "^5.2.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@docusaurus/logger": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.9.2.tgz",
-      "integrity": "sha512-/SVCc57ByARzGSU60c50rMyQlBuMIJCjcsJlkphxY6B0GV4UH3tcA1994N8fFfbJ9kX3jIBe/xg3XP5qBtGDbA==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.9.2.tgz",
-      "integrity": "sha512-wiYoGwF9gdd6rev62xDU8AAM8JuLI/hlwOtCzMmYcspEkzecKrP8J8X+KpYnTlACBUUtXNJpSoCwFWJhLRevzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^2.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=20.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.2.tgz",
-      "integrity": "sha512-8qVe2QA9hVLzvnxP46ysuofJUIc/yYQ82tvA/rBTrnpXtCjNSFLxEZfd5U8cYZuJIVlkPxamsIgwd5tGZXfvew==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.9.2",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.9.2.tgz",
-      "integrity": "sha512-3I2HXy3L1QcjLJLGAoTvoBnpOwa6DPUa3Q0dMK19UTY9mhPkKQg/DYhAGTiBUKcTR0f08iw7kLPqOhIgdV3eVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/mdx-loader": "3.9.2",
-        "@docusaurus/theme-common": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-common": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
-        "cheerio": "1.0.0-rc.12",
-        "feed": "^4.2.2",
-        "fs-extra": "^11.1.1",
-        "lodash": "^4.17.21",
-        "schema-dts": "^1.1.2",
-        "srcset": "^4.0.0",
-        "tslib": "^2.6.0",
-        "unist-util-visit": "^5.0.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=20.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/plugin-content-docs": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/theme-common": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.9.2.tgz",
-      "integrity": "sha512-6c4DAbR6n6nPbnZhY2V3tzpnKnGL+6aOsLvFL26VRqhlczli9eWG0VDUNoCQEPnGwDMhPS42UhSAnz5pThm5Ag==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/mdx-loader": "3.9.2",
-        "@docusaurus/module-type-aliases": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-common": "3.9.2",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "clsx": "^2.0.0",
-        "parse-numeric-range": "^1.3.0",
-        "prism-react-renderer": "^2.3.0",
-        "tslib": "^2.6.0",
-        "utility-types": "^3.10.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/plugin-content-docs": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.0.tgz",
-      "integrity": "sha512-9BjHhf15ct8Z7TThTC0xRndKDVvMKmVsAGAN7W9FpNRzfMdScOGcXtLmcCWtJGvAezjOJIm6CxOYCy3Io5+RnQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/core": "3.10.0",
-        "@docusaurus/logger": "3.10.0",
-        "@docusaurus/mdx-loader": "3.10.0",
-        "@docusaurus/module-type-aliases": "3.10.0",
-        "@docusaurus/theme-common": "3.10.0",
-        "@docusaurus/types": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
-        "@docusaurus/utils-common": "3.10.0",
-        "@docusaurus/utils-validation": "3.10.0",
-        "@types/react-router-config": "^5.0.7",
-        "combine-promises": "^1.1.0",
-        "fs-extra": "^11.1.1",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "schema-dts": "^1.1.2",
-        "tslib": "^2.6.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=20.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/babel": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.10.0.tgz",
-      "integrity": "sha512-mqCJhCZNZUDg0zgDEaPTM4DnRsisa24HdqTy/qn/MQlbwhTb4WVaZg6ZyX6yIVKqTz8fS1hBMgM+98z+BeJJDg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.25.9",
-        "@babel/generator": "^7.25.9",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.25.9",
-        "@babel/preset-env": "^7.25.9",
-        "@babel/preset-react": "^7.25.9",
-        "@babel/preset-typescript": "^7.25.9",
-        "@babel/runtime": "^7.25.9",
-        "@babel/traverse": "^7.25.9",
-        "@docusaurus/logger": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "fs-extra": "^11.1.1",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/bundler": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.10.0.tgz",
-      "integrity": "sha512-iONUGZGgp+lAkw/cJZH6irONcF4p8+278IsdRlq8lYhxGjkoNUs0w7F4gVXBYSNChq5KG5/JleTSsdJySShxow==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.25.9",
-        "@docusaurus/babel": "3.10.0",
-        "@docusaurus/cssnano-preset": "3.10.0",
-        "@docusaurus/logger": "3.10.0",
-        "@docusaurus/types": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
-        "babel-loader": "^9.2.1",
-        "clean-css": "^5.3.3",
-        "copy-webpack-plugin": "^11.0.0",
-        "css-loader": "^6.11.0",
-        "css-minimizer-webpack-plugin": "^5.0.1",
-        "cssnano": "^6.1.2",
-        "file-loader": "^6.2.0",
-        "html-minifier-terser": "^7.2.0",
-        "mini-css-extract-plugin": "^2.9.2",
-        "null-loader": "^4.0.1",
-        "postcss": "^8.5.4",
-        "postcss-loader": "^7.3.4",
-        "postcss-preset-env": "^10.2.1",
-        "terser-webpack-plugin": "^5.3.9",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.95.0",
-        "webpackbar": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=20.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/faster": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/faster": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/core": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.10.0.tgz",
-      "integrity": "sha512-mgLdQsO8xppnQZc3LPi+Mf+PkPeyxJeIx11AXAq/14fsaMefInQiMEZUUmrc7J+956G/f7MwE7tn8KZgi3iRcA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/babel": "3.10.0",
-        "@docusaurus/bundler": "3.10.0",
-        "@docusaurus/logger": "3.10.0",
-        "@docusaurus/mdx-loader": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
-        "@docusaurus/utils-common": "3.10.0",
-        "@docusaurus/utils-validation": "3.10.0",
+        "@docusaurus/babel": "3.10.1",
+        "@docusaurus/bundler": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/mdx-loader": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -3815,10 +3551,10 @@
         }
       }
     },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.10.0.tgz",
-      "integrity": "sha512-qzSshTO1DB3TYW+dPUal5KHM7XPc5YQfzF3Kdb2NDACJUyGbNcFtw3tGkCJlYwhNCRKbZcmwraKUS1i5dcHdGg==",
+    "node_modules/@docusaurus/cssnano-preset": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.10.1.tgz",
+      "integrity": "sha512-eNfHGcTKCSq6xmcavAkX3RRclHaE2xRCMParlDXLdXVP01/a2e/jKXMj/0ULnLFQSNwwuI62L0Ge8J+nZsR7UQ==",
       "license": "MIT",
       "dependencies": {
         "cssnano-preset-advanced": "^6.1.2",
@@ -3830,10 +3566,10 @@
         "node": ">=20.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/logger": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.10.0.tgz",
-      "integrity": "sha512-9jrZzFuBH1LDRlZ7cznAhCLmAZ3HSDqgwdrSSZdGHq9SPUOQgXXu8mnxe2ZRB9NS1PCpMTIOVUqDtZPIhMafZg==",
+    "node_modules/@docusaurus/logger": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.10.1.tgz",
+      "integrity": "sha512-oPjNFnfJsRCkePVjkGrxWGq4MvJKRQT0r9jOP0eRBTZ7Wr9FAbzdP/Gjs0I2Ss6YRkPoEgygKG112OkE6skvJw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -3843,15 +3579,15 @@
         "node": ">=20.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.10.0.tgz",
-      "integrity": "sha512-mQQV97080AH4PYNs087l202NMDqRopZA4mg5W76ZZyTFrmWhJ3mHg+8A+drJVENxw5/Q+wHMHLgsx+9z1nEs0A==",
+    "node_modules/@docusaurus/mdx-loader": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.10.1.tgz",
+      "integrity": "sha512-GRmeb/wQ+iXRrFwcHBfgQhrJxGElgCsoTWZYDhccjsZVne1p8MK/EpQVIloXttz76TCe78kKD5AEG9n1xc1oxQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
-        "@docusaurus/utils-validation": "3.10.0",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -3882,13 +3618,13 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.0.tgz",
-      "integrity": "sha512-/1O0Zg8w3DFrYX/I6Fbss7OJrtZw1QoyjDhegiFNHVi9A9Y0gQ3jUAytVxF6ywpAWpLyLxch8nN8H/V3XfzdJQ==",
+    "node_modules/@docusaurus/module-type-aliases": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.1.tgz",
+      "integrity": "sha512-YoOZKUdGlp8xSYhuAkGdSo5Ydkbq4V4eK3sD8v0a2hloxCWdQbNBhkc+Ko9QyjpESc0BYcIGM5iHVAy5hdFV6w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.10.0",
+        "@docusaurus/types": "3.10.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -3901,316 +3637,56 @@
         "react-dom": "*"
       }
     },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/types": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.0.tgz",
-      "integrity": "sha512-F0dOt3FOoO20rRaFK7whGFQZ3ggyrWEdQc/c8/UiRuzhtg4y1w9FspXH5zpCT07uMnJKBPGh+qNazbNlCQqvSw==",
+    "node_modules/@docusaurus/plugin-content-blog": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.10.1.tgz",
+      "integrity": "sha512-mmkgE6Q2+K74tnkou7tXlpDLvoCU/qkSa2GSQ3XUiHWvcebCoDQzS670RR3tO8PmaWlIyWWISYWzZLuMfxunRA==",
       "license": "MIT",
       "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/types/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/utils": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.10.0.tgz",
-      "integrity": "sha512-T3B0WTigsIthe0D4LQa2k+7bJY+c3WS+Wq2JhcznOSpn1lSN64yNtHQXboCj3QnUs1EuAZszQG1SHKu5w5ZrlA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.10.0",
-        "@docusaurus/types": "3.10.0",
-        "@docusaurus/utils-common": "3.10.0",
-        "escape-string-regexp": "^4.0.0",
-        "execa": "^5.1.1",
-        "file-loader": "^6.2.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/mdx-loader": "3.10.1",
+        "@docusaurus/theme-common": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
+        "cheerio": "1.0.0-rc.12",
+        "combine-promises": "^1.1.0",
+        "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "p-queue": "^6.6.2",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
+        "schema-dts": "^1.1.2",
+        "srcset": "^4.0.0",
         "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
+        "unist-util-visit": "^5.0.0",
         "utility-types": "^3.10.0",
         "webpack": "^5.88.1"
       },
       "engines": {
         "node": ">=20.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/utils-common": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.10.0.tgz",
-      "integrity": "sha512-JyL7sb9QVDgYvudIS81Dv0lsWm7le0vGZSDwsztxWam1SPBqrnkvBy9UYL/amh6pbybkyYTd3CMTkO24oMlCSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.10.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/utils-validation": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.10.0.tgz",
-      "integrity": "sha512-c+6n2+ZPOJtWWc8Bb/EYdpSDfjYEScdCu9fB/SNjOmSCf1IdVnGf2T53o0tsz0gDRtCL90tifTL0JE/oMuP1Mw==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
-        "@docusaurus/utils-common": "3.10.0",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.9.2.tgz",
-      "integrity": "sha512-s4849w/p4noXUrGpPUF0BPqIAfdAe76BLaRGAGKZ1gTDNiGxGcpsLcwJ9OTi1/V8A+AzvsmI9pkjie2zjIQZKA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/mdx-loader": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
-        "fs-extra": "^11.1.1",
-        "tslib": "^2.6.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=20.0"
       },
       "peerDependencies": {
+        "@docusaurus/plugin-content-docs": "*",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-css-cascade-layers": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.9.2.tgz",
-      "integrity": "sha512-w1s3+Ss+eOQbscGM4cfIFBlVg/QKxyYgj26k5AnakuHkKxH6004ZtuLe5awMBotIYF2bbGDoDhpgQ4r/kcj4rQ==",
+    "node_modules/@docusaurus/plugin-content-docs": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.1.tgz",
+      "integrity": "sha512-2jRVrtzjf8LClGTHQlwlwuD3wQXRx3WEoF7XUarJ8Ou+0onV+SLtejsyfY9JLpfUh9hPhXM4pbBGkyAY4Bi3HQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.9.2.tgz",
-      "integrity": "sha512-j7a5hWuAFxyQAkilZwhsQ/b3T7FfHZ+0dub6j/GxKNFJp2h9qk/P1Bp7vrGASnvA9KNQBBL1ZXTe7jlh4VdPdA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "fs-extra": "^11.1.1",
-        "react-json-view-lite": "^2.3.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.9.2.tgz",
-      "integrity": "sha512-mAwwQJ1Us9jL/lVjXtErXto4p4/iaLlweC54yDUK1a97WfkC6Z2k5/769JsFgwOwOP+n5mUQGACXOEQ0XDuVUw==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.9.2.tgz",
-      "integrity": "sha512-YJ4lDCphabBtw19ooSlc1MnxtYGpjFV9rEdzjLsUnBCeis2djUyCozZaFhCg6NGEwOn7HDDyMh0yzcdRpnuIvA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
-        "@types/gtag.js": "^0.0.12",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.9.2.tgz",
-      "integrity": "sha512-LJtIrkZN/tuHD8NqDAW1Tnw0ekOwRTfobWPsdO15YxcicBo2ykKF0/D6n0vVBfd3srwr9Z6rzrIWYrMzBGrvNw==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.9.2.tgz",
-      "integrity": "sha512-WLh7ymgDXjG8oPoM/T4/zUP7KcSuFYRZAUTl8vR6VzYkfc18GBM4xLhcT+AKOwun6kBivYKUJf+vlqYJkm+RHw==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-common": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
-        "fs-extra": "^11.1.1",
-        "sitemap": "^7.1.1",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-svgr": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.9.2.tgz",
-      "integrity": "sha512-n+1DE+5b3Lnf27TgVU5jM1d4x5tUh2oW5LTsBxJX4PsAPV0JGcmI6p3yLYtEY0LRVEIJh+8RsdQmRE66wSV8mw==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
-        "@svgr/core": "8.1.0",
-        "@svgr/webpack": "^8.1.0",
-        "tslib": "^2.6.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=20.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.9.2.tgz",
-      "integrity": "sha512-IgyYO2Gvaigi21LuDIe+nvmN/dfGXAiMcV/murFqcpjnZc7jxFAxW+9LEjdPt61uZLxG4ByW/oUmX/DDK9t/8w==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/plugin-content-blog": "3.9.2",
-        "@docusaurus/plugin-content-docs": "3.9.2",
-        "@docusaurus/plugin-content-pages": "3.9.2",
-        "@docusaurus/plugin-css-cascade-layers": "3.9.2",
-        "@docusaurus/plugin-debug": "3.9.2",
-        "@docusaurus/plugin-google-analytics": "3.9.2",
-        "@docusaurus/plugin-google-gtag": "3.9.2",
-        "@docusaurus/plugin-google-tag-manager": "3.9.2",
-        "@docusaurus/plugin-sitemap": "3.9.2",
-        "@docusaurus/plugin-svgr": "3.9.2",
-        "@docusaurus/theme-classic": "3.9.2",
-        "@docusaurus/theme-common": "3.9.2",
-        "@docusaurus/theme-search-algolia": "3.9.2",
-        "@docusaurus/types": "3.9.2"
-      },
-      "engines": {
-        "node": ">=20.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
-      "integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/mdx-loader": "3.9.2",
-        "@docusaurus/module-type-aliases": "3.9.2",
-        "@docusaurus/theme-common": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-common": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/mdx-loader": "3.10.1",
+        "@docusaurus/module-type-aliases": "3.10.1",
+        "@docusaurus/theme-common": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -4229,55 +3705,223 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/theme-common": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.9.2.tgz",
-      "integrity": "sha512-6c4DAbR6n6nPbnZhY2V3tzpnKnGL+6aOsLvFL26VRqhlczli9eWG0VDUNoCQEPnGwDMhPS42UhSAnz5pThm5Ag==",
+    "node_modules/@docusaurus/plugin-content-pages": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.10.1.tgz",
+      "integrity": "sha512-huJpaRPMl42nsFwuCXvV8bVDj2MazuwRJIUylI/RSlmZeJssVoZXeCjVf1y+1Drtpa9SKcdGn8yoJ76IRJijtw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.9.2",
-        "@docusaurus/module-type-aliases": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-common": "3.9.2",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "clsx": "^2.0.0",
-        "parse-numeric-range": "^1.3.0",
-        "prism-react-renderer": "^2.3.0",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/mdx-loader": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
+        "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
-        "utility-types": "^3.10.0"
+        "webpack": "^5.88.1"
       },
       "engines": {
         "node": ">=20.0"
       },
       "peerDependencies": {
-        "@docusaurus/plugin-content-docs": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-css-cascade-layers": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.10.1.tgz",
+      "integrity": "sha512-r//fn+MNHkE1wCof8T29VAQezt1enGCpsFxoziBbvLgBM4JfXN2P3rxrBaavHmvLvm7lYkpJeitcDthwnmWCTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-debug": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.10.1.tgz",
+      "integrity": "sha512-9KqOpKNfAyqGZykRb9LhIT/vyRF6sm/ykhjj/39JvaJahDS+jZJE0Z1Wfz9q3DUNDTMNN0Q7u/kk4rKKU+IJuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "fs-extra": "^11.1.1",
+        "react-json-view-lite": "^2.3.0",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-analytics": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.10.1.tgz",
+      "integrity": "sha512-8o0P1KtmgdYQHH+oInitPpRWI0Of5XednAX4+DMhQNSmGSRNrsEEHg1ebv35m9AgRClfAytCJ5jA9KvcASTyuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-gtag": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.10.1.tgz",
+      "integrity": "sha512-pu3xIUo5o/zCMLfUY9BO5KOwSH0zIsAGyFRPvXHayFSA5XIhCU/SFuB0g0ZNjFn9niZLCaNvoeAuOGFJZq0fdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
+        "@types/gtag.js": "^0.0.20",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-tag-manager": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.10.1.tgz",
+      "integrity": "sha512-f6fyGHiCm7kJHBtAisGQS5oNBnpnMTYQZxDXeVrnw/3zWU+LMA22pr6UHGYkBKDbN+qPC5QHG3NuOfzQLq3+Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-sitemap": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.10.1.tgz",
+      "integrity": "sha512-C26MbmmqgdjkDq1htaZ3aD7LzEDKFWXfpyQpt0EOUThuq5nV77zDaedV20yHcVo9p+3ey9aZ4pbHA0D3QcZTzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
+        "fs-extra": "^11.1.1",
+        "sitemap": "^7.1.1",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-svgr": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.10.1.tgz",
+      "integrity": "sha512-6SFxsmjWFkVLDmBUvFK6i72QjUwqyQFe4Ovz+SUJophJjOyVG3ZZG5IQpBC/kX/Gfv1yWeU9nWauH6F6Q7QX/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
+        "@svgr/core": "8.1.0",
+        "@svgr/webpack": "^8.1.0",
+        "tslib": "^2.6.0",
+        "webpack": "^5.88.1"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/preset-classic": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.10.1.tgz",
+      "integrity": "sha512-YO/FL8v1zmbxoTso6mjMz/RDjhaTJxb1UpFFTDdY5847LLDCeyYiYlrhyTbgN1RIN3xnkLKZ9Lj1x8hUzI4JOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/plugin-content-blog": "3.10.1",
+        "@docusaurus/plugin-content-docs": "3.10.1",
+        "@docusaurus/plugin-content-pages": "3.10.1",
+        "@docusaurus/plugin-css-cascade-layers": "3.10.1",
+        "@docusaurus/plugin-debug": "3.10.1",
+        "@docusaurus/plugin-google-analytics": "3.10.1",
+        "@docusaurus/plugin-google-gtag": "3.10.1",
+        "@docusaurus/plugin-google-tag-manager": "3.10.1",
+        "@docusaurus/plugin-sitemap": "3.10.1",
+        "@docusaurus/plugin-svgr": "3.10.1",
+        "@docusaurus/theme-classic": "3.10.1",
+        "@docusaurus/theme-common": "3.10.1",
+        "@docusaurus/theme-search-algolia": "3.10.1",
+        "@docusaurus/types": "3.10.1"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.9.2.tgz",
-      "integrity": "sha512-IGUsArG5hhekXd7RDb11v94ycpJpFdJPkLnt10fFQWOVxAtq5/D7hT6lzc2fhyQKaaCE62qVajOMKL7OiAFAIA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.10.1.tgz",
+      "integrity": "sha512-VU1RK0qb2pab0si4r7HFK37cYco8VzqLj3u1PspVipSr/z/GPVKHO4/HXbnePqHoWDk8urjyGSeatH0NIMBM1A==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/mdx-loader": "3.9.2",
-        "@docusaurus/module-type-aliases": "3.9.2",
-        "@docusaurus/plugin-content-blog": "3.9.2",
-        "@docusaurus/plugin-content-docs": "3.9.2",
-        "@docusaurus/plugin-content-pages": "3.9.2",
-        "@docusaurus/theme-common": "3.9.2",
-        "@docusaurus/theme-translations": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-common": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/mdx-loader": "3.10.1",
+        "@docusaurus/module-type-aliases": "3.10.1",
+        "@docusaurus/plugin-content-blog": "3.10.1",
+        "@docusaurus/plugin-content-docs": "3.10.1",
+        "@docusaurus/plugin-content-pages": "3.10.1",
+        "@docusaurus/theme-common": "3.10.1",
+        "@docusaurus/theme-translations": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
+        "copy-text-to-clipboard": "^3.2.0",
         "infima": "0.2.0-alpha.45",
         "lodash": "^4.17.21",
         "nprogress": "^0.2.0",
@@ -4297,77 +3941,16 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
-      "integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/mdx-loader": "3.9.2",
-        "@docusaurus/module-type-aliases": "3.9.2",
-        "@docusaurus/theme-common": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-common": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
-        "@types/react-router-config": "^5.0.7",
-        "combine-promises": "^1.1.0",
-        "fs-extra": "^11.1.1",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "schema-dts": "^1.1.2",
-        "tslib": "^2.6.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=20.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/theme-common": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.9.2.tgz",
-      "integrity": "sha512-6c4DAbR6n6nPbnZhY2V3tzpnKnGL+6aOsLvFL26VRqhlczli9eWG0VDUNoCQEPnGwDMhPS42UhSAnz5pThm5Ag==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/mdx-loader": "3.9.2",
-        "@docusaurus/module-type-aliases": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-common": "3.9.2",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "clsx": "^2.0.0",
-        "parse-numeric-range": "^1.3.0",
-        "prism-react-renderer": "^2.3.0",
-        "tslib": "^2.6.0",
-        "utility-types": "^3.10.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/plugin-content-docs": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.0.tgz",
-      "integrity": "sha512-Dkp1YXKn16ByCJAdIjbDIOpVb4Z66MsVD694/ilX1vAAHaVEMrVsf/NPd9VgreyFx08rJ9GqV1MtzsbTcU73Kg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.1.tgz",
+      "integrity": "sha512-0YtmIeoNo1fIw65LO8+/1dPgmDV86UmhMkow37gzjytuiCSQm9xob6PJy0L4kuQEMTLfUOGvkXvZr7GPrHquMA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.10.0",
-        "@docusaurus/module-type-aliases": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
-        "@docusaurus/utils-common": "3.10.0",
+        "@docusaurus/mdx-loader": "3.10.1",
+        "@docusaurus/module-type-aliases": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -4384,193 +3967,23 @@
         "@docusaurus/plugin-content-docs": "*",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/logger": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.10.0.tgz",
-      "integrity": "sha512-9jrZzFuBH1LDRlZ7cznAhCLmAZ3HSDqgwdrSSZdGHq9SPUOQgXXu8mnxe2ZRB9NS1PCpMTIOVUqDtZPIhMafZg==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.10.0.tgz",
-      "integrity": "sha512-mQQV97080AH4PYNs087l202NMDqRopZA4mg5W76ZZyTFrmWhJ3mHg+8A+drJVENxw5/Q+wHMHLgsx+9z1nEs0A==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
-        "@docusaurus/utils-validation": "3.10.0",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^2.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=20.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.0.tgz",
-      "integrity": "sha512-/1O0Zg8w3DFrYX/I6Fbss7OJrtZw1QoyjDhegiFNHVi9A9Y0gQ3jUAytVxF6ywpAWpLyLxch8nN8H/V3XfzdJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.10.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/types": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.0.tgz",
-      "integrity": "sha512-F0dOt3FOoO20rRaFK7whGFQZ3ggyrWEdQc/c8/UiRuzhtg4y1w9FspXH5zpCT07uMnJKBPGh+qNazbNlCQqvSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/mdast": "^4.0.2",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.95.0",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/utils": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.10.0.tgz",
-      "integrity": "sha512-T3B0WTigsIthe0D4LQa2k+7bJY+c3WS+Wq2JhcznOSpn1lSN64yNtHQXboCj3QnUs1EuAZszQG1SHKu5w5ZrlA==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.10.0",
-        "@docusaurus/types": "3.10.0",
-        "@docusaurus/utils-common": "3.10.0",
-        "escape-string-regexp": "^4.0.0",
-        "execa": "^5.1.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "p-queue": "^6.6.2",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/utils-common": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.10.0.tgz",
-      "integrity": "sha512-JyL7sb9QVDgYvudIS81Dv0lsWm7le0vGZSDwsztxWam1SPBqrnkvBy9UYL/amh6pbybkyYTd3CMTkO24oMlCSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/types": "3.10.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/utils-validation": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.10.0.tgz",
-      "integrity": "sha512-c+6n2+ZPOJtWWc8Bb/EYdpSDfjYEScdCu9fB/SNjOmSCf1IdVnGf2T53o0tsz0gDRtCL90tifTL0JE/oMuP1Mw==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/logger": "3.10.0",
-        "@docusaurus/utils": "3.10.0",
-        "@docusaurus/utils-common": "3.10.0",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/webpack-merge": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-      "license": "MIT",
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "flat": "^5.0.2",
-        "wildcard": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.9.2.tgz",
-      "integrity": "sha512-GBDSFNwjnh5/LdkxCKQHkgO2pIMX1447BxYUBG2wBiajS21uj64a+gH/qlbQjDLxmGrbrllBrtJkUHxIsiwRnw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.10.1.tgz",
+      "integrity": "sha512-OTaARARVZj2GvkJQjB+1jOIxntRaXea+G+fMsNqrZBAU1O1vJKDW22R7kECOHW27oJCLFN9HKaZeRrfAUyviug==",
       "license": "MIT",
       "dependencies": {
-        "@docsearch/react": "^3.9.0 || ^4.1.0",
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/plugin-content-docs": "3.9.2",
-        "@docusaurus/theme-common": "3.9.2",
-        "@docusaurus/theme-translations": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
+        "@algolia/autocomplete-core": "^1.19.2",
+        "@docsearch/react": "^3.9.0 || ^4.3.2",
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/plugin-content-docs": "3.10.1",
+        "@docusaurus/theme-common": "3.10.1",
+        "@docusaurus/theme-translations": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
         "algoliasearch": "^5.37.0",
         "algoliasearch-helper": "^3.26.0",
         "clsx": "^2.0.0",
@@ -4588,71 +4001,10 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
-      "integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/core": "3.9.2",
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/mdx-loader": "3.9.2",
-        "@docusaurus/module-type-aliases": "3.9.2",
-        "@docusaurus/theme-common": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-common": "3.9.2",
-        "@docusaurus/utils-validation": "3.9.2",
-        "@types/react-router-config": "^5.0.7",
-        "combine-promises": "^1.1.0",
-        "fs-extra": "^11.1.1",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "schema-dts": "^1.1.2",
-        "tslib": "^2.6.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=20.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/theme-common": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.9.2.tgz",
-      "integrity": "sha512-6c4DAbR6n6nPbnZhY2V3tzpnKnGL+6aOsLvFL26VRqhlczli9eWG0VDUNoCQEPnGwDMhPS42UhSAnz5pThm5Ag==",
-      "license": "MIT",
-      "dependencies": {
-        "@docusaurus/mdx-loader": "3.9.2",
-        "@docusaurus/module-type-aliases": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-common": "3.9.2",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "clsx": "^2.0.0",
-        "parse-numeric-range": "^1.3.0",
-        "prism-react-renderer": "^2.3.0",
-        "tslib": "^2.6.0",
-        "utility-types": "^3.10.0"
-      },
-      "engines": {
-        "node": ">=20.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/plugin-content-docs": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.9.2.tgz",
-      "integrity": "sha512-vIryvpP18ON9T9rjgMRFLr2xJVDpw1rtagEGf8Ccce4CkTrvM/fRB8N2nyWYOW5u3DdjkwKw5fBa+3tbn9P4PA==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.10.1.tgz",
+      "integrity": "sha512-cLMyaKivjBVWKMJuWqyFVVgtqe8DPJNPkog0bn8W1MDVAKcPdxRFycBfC1We1RaNp7Rdk513bmtW78RR6OBxBw==",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",
@@ -4663,9 +4015,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-      "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
@@ -4699,16 +4051,16 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.9.2.tgz",
-      "integrity": "sha512-lBSBiRruFurFKXr5Hbsl2thmGweAPmddhF3jb99U4EMDA5L+e5Y1rAkOS07Nvrup7HUMBDrCV45meaxZnt28nQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.10.1.tgz",
+      "integrity": "sha512-3ojeJry9xBYdJO6qoyyzqeJFSJBVx2mXhyDzSdjwL2+URFQMf+h25gG38iswGImicK0ELjTd1EL2xzk8hf3QPw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/types": "3.9.2",
-        "@docusaurus/utils-common": "3.9.2",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
         "escape-string-regexp": "^4.0.0",
-        "execa": "5.1.1",
+        "execa": "^5.1.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^11.1.1",
         "github-slugger": "^1.5.0",
@@ -4731,12 +4083,12 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.9.2.tgz",
-      "integrity": "sha512-I53UC1QctruA6SWLvbjbhCpAw7+X7PePoe5pYcwTOEXD/PxeP8LnECAhTHHwWCblyUX5bMi4QLRkxvyZ+IT8Aw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.10.1.tgz",
+      "integrity": "sha512-5mFSgEADtnFxFH7RLw02QA5MpU5JVUCj0MPeIvi/aF4Fi45tQRIuTwXoXDqJ+1VfQJuYJGz3SI63wmGz4HvXzA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.9.2",
+        "@docusaurus/types": "3.10.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -4744,14 +4096,14 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.9.2.tgz",
-      "integrity": "sha512-l7yk3X5VnNmATbwijJkexdhulNsQaNDwoagiwujXoxFbWLcxHQqNQ+c/IAlzrfMMOfa/8xSBZ7KEKDesE/2J7A==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.10.1.tgz",
+      "integrity": "sha512-cRv1X69jwaWv47waglllgZVWzeBFLhl53XT/XED/83BerVBTC5FTP8WTcVl8Z6sZOegDSwitu/wpCSPCDOT6lg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.9.2",
-        "@docusaurus/utils": "3.9.2",
-        "@docusaurus/utils-common": "3.9.2",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
         "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
@@ -6682,9 +6034,9 @@
       }
     },
     "node_modules/@types/gtag.js": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.12.tgz",
-      "integrity": "sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.20.tgz",
+      "integrity": "sha512-wwAbk3SA2QeU67unN7zPxjEHmPmlXwZXZvQEpbEUQuMCRGgKyE1m6XDuTUA9b6pCGb/GqJmdfMOY5LuDjJSbbg==",
       "license": "MIT"
     },
     "node_modules/@types/hast": {
@@ -7267,34 +6619,34 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "5.50.2",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.50.2.tgz",
-      "integrity": "sha512-Tfp26yoNWurUjfgK4GOrVJQhSNXu9tJtHfFFNosgT2YClG+vPyUjX/gbC8rG39qLncnZg8Fj34iarQWpMkqefw==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.55.0.tgz",
+      "integrity": "sha512-af+rI+tUVeS9KWHPAZQHIHPOIC3StPRR6IwQu2nz1aQoTL6Gs5Ty3KsHCgbXMHOpoh9QqSjq8F3KJ8xmaCZSBA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/abtesting": "1.16.2",
-        "@algolia/client-abtesting": "5.50.2",
-        "@algolia/client-analytics": "5.50.2",
-        "@algolia/client-common": "5.50.2",
-        "@algolia/client-insights": "5.50.2",
-        "@algolia/client-personalization": "5.50.2",
-        "@algolia/client-query-suggestions": "5.50.2",
-        "@algolia/client-search": "5.50.2",
-        "@algolia/ingestion": "1.50.2",
-        "@algolia/monitoring": "1.50.2",
-        "@algolia/recommend": "5.50.2",
-        "@algolia/requester-browser-xhr": "5.50.2",
-        "@algolia/requester-fetch": "5.50.2",
-        "@algolia/requester-node-http": "5.50.2"
+        "@algolia/abtesting": "1.21.0",
+        "@algolia/client-abtesting": "5.55.0",
+        "@algolia/client-analytics": "5.55.0",
+        "@algolia/client-common": "5.55.0",
+        "@algolia/client-insights": "5.55.0",
+        "@algolia/client-personalization": "5.55.0",
+        "@algolia/client-query-suggestions": "5.55.0",
+        "@algolia/client-search": "5.55.0",
+        "@algolia/ingestion": "1.55.0",
+        "@algolia/monitoring": "1.55.0",
+        "@algolia/recommend": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.28.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.28.1.tgz",
-      "integrity": "sha512-6iXpbkkrAI5HFpCWXlNmIDSBuoN/U1XnEvb2yJAoWfqrZ+DrybI7MQ5P5mthFaprmocq+zbi6HxnR28xnZAYBw==",
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.29.1.tgz",
+      "integrity": "sha512-6ck2YFudF2Pje7szQoPBiRFTGfd+1I+0I/WfLPGn0bj1kvrFoOQmNyedNiDxTk3/r4IfSLDYk+RA4G7u8H6+yA==",
       "license": "MIT",
       "dependencies": {
         "@algolia/events": "^4.0.1"
@@ -7332,33 +6684,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ansi-html-community": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
@@ -7393,6 +6718,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansis": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.17.0.tgz",
+      "integrity": "sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/anymatch": {
@@ -8442,6 +7776,18 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
+    "node_modules/copy-text-to-clipboard": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.2.tgz",
+      "integrity": "sha512-T6SqyLd1iLuqPA90J5N4cTalrtovCySh58iiZDGJ6FGznbclKh4UI+FGacQSgFzwKG77W7XT5gwbVEbd9cIH1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/copy-webpack-plugin": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz",
@@ -8528,17 +7874,6 @@
       "dependencies": {
         "browserslist": "^4.28.1"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/core-js-pure": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
-      "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
-      "hasInstallScript": true,
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -10059,30 +9394,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "license": "MIT",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/figures/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/file-loader": {
@@ -17420,15 +16731,6 @@
         "entities": "^2.0.0"
       }
     },
-    "node_modules/repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -19595,78 +18897,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/webpackbar": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpackbar/-/webpackbar-6.0.1.tgz",
-      "integrity": "sha512-TnErZpmuKdwWBdMoexjio3KKX6ZtoKHRVvLIU0A47R0VVBDtx3ZyOJDktgYixhoJokZTYTt1Z37OkO9pnGJa9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^4.3.2",
-        "chalk": "^4.1.2",
-        "consola": "^3.2.3",
-        "figures": "^3.2.0",
-        "markdown-table": "^2.0.0",
-        "pretty-time": "^1.1.0",
-        "std-env": "^3.7.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.21.3"
-      },
-      "peerDependencies": {
-        "webpack": "3 || 4 || 5"
-      }
-    },
-    "node_modules/webpackbar/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
-    },
-    "node_modules/webpackbar/node_modules/markdown-table": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
-      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
-      "license": "MIT",
-      "dependencies": {
-        "repeat-string": "^1.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/webpackbar/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/webpackbar/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/websocket-driver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@docusaurus/core": "3.10.1",
         "@docusaurus/preset-classic": "3.10.1",
+        "@docusaurus/theme-mermaid": "3.10.1",
         "@easyops-cn/docusaurus-search-local": "^0.55.0",
         "@iarna/toml": "^2.2.5",
         "@mdx-js/react": "^3.0.0",
@@ -260,6 +261,19 @@
       },
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1962,6 +1976,18 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -3969,6 +3995,34 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@docusaurus/theme-mermaid": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.10.1.tgz",
+      "integrity": "sha512-2gxpmln8Pc4EN1oWzshQEx2HTs67jk14v7MmgqGs8ZU7Nm8oihg+fTouof2u4vN8DtB3Fln4cDJu4UprSX1S3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/module-type-aliases": "3.10.1",
+        "@docusaurus/theme-common": "3.10.1",
+        "@docusaurus/types": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
+        "mermaid": ">=11.6.0",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "@mermaid-js/layout-elk": "^0.1.9",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@mermaid-js/layout-elk": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@docusaurus/theme-search-algolia": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.10.1.tgz",
@@ -4538,6 +4592,23 @@
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
       "license": "ISC"
     },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -5089,6 +5160,15 @@
       "peerDependencies": {
         "@types/react": ">=16",
         "react": ">=16"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.2"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -5965,6 +6045,259 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.4.tgz",
+      "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -6032,6 +6365,12 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/gtag.js": {
       "version": "0.0.20",
@@ -6269,6 +6608,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -6304,6 +6650,16 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
@@ -7885,6 +8241,15 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "8.3.6",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
@@ -8370,6 +8735,532 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/cytoscape": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
     "node_modules/debounce": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
@@ -8531,6 +9422,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -8667,6 +9567,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -8889,6 +9798,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
+      "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esast-util-from-estree": {
       "version": "2.0.0",
@@ -9902,6 +10821,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -10541,6 +11466,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -10588,6 +11523,15 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/invariant": {
       "version": "2.2.4",
@@ -11084,6 +12028,31 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -11092,6 +12061,11 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -11144,6 +12118,12 @@
         "picocolors": "^1.1.1",
         "shell-quote": "^1.8.3"
       }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -11218,6 +12198,12 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -11328,6 +12314,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {
@@ -11807,6 +12805,48 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.16.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
+      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.2",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.2.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.3",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.45",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/methods": {
@@ -14172,6 +15212,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.7.0.tgz",
+      "integrity": "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==",
+      "license": "MIT"
+    },
     "node_modules/param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -14311,6 +15357,12 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
@@ -14407,6 +15459,22 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/postcss": {
@@ -16830,6 +17898,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
     "node_modules/rtlcss": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-4.3.0.tgz",
@@ -16882,6 +17968,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -17715,6 +18807,12 @@
         "postcss": "^8.4.31"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -17912,6 +19010,15 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "license": "MIT"
     },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinypool": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
@@ -17985,6 +19092,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "3.9.2",
-    "@docusaurus/preset-classic": "3.9.2",
+    "@docusaurus/core": "3.10.1",
+    "@docusaurus/preset-classic": "3.10.1",
     "@easyops-cn/docusaurus-search-local": "^0.55.0",
     "@iarna/toml": "^2.2.5",
     "@mdx-js/react": "^3.0.0",
@@ -28,8 +28,8 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.9.2",
-    "@docusaurus/types": "3.9.2"
+    "@docusaurus/module-type-aliases": "3.10.1",
+    "@docusaurus/types": "3.10.1"
   },
   "browserslist": {
     "production": [

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@docusaurus/core": "3.10.1",
     "@docusaurus/preset-classic": "3.10.1",
+    "@docusaurus/theme-mermaid": "3.10.1",
     "@easyops-cn/docusaurus-search-local": "^0.55.0",
     "@iarna/toml": "^2.2.5",
     "@mdx-js/react": "^3.0.0",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -129,3 +129,9 @@ b, strong {
 .theme-edit-this-page {
   display: none !important;
 }
+
+/* Center Mermaid diagrams within the content column */
+.docusaurus-mermaid-container {
+  display: flex;
+  justify-content: center;
+}

--- a/versioned_docs/version-v1.15.0/KeyFeatures/HierarchicalQueue.md
+++ b/versioned_docs/version-v1.15.0/KeyFeatures/HierarchicalQueue.md
@@ -39,6 +39,42 @@ data:
       - name: nodeorder
 ```
 
+### Configure Ancestor Reclaim Scope
+
+`ancestorReclaimLevel` is configured as an argument of the `capacity` plugin. It is only meaningful when hierarchical queue mode is enabled with `enableHierarchy: true` and the scheduler has the `reclaim` action enabled.
+
+```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: volcano-scheduler-configmap
+  namespace: volcano-system
+data:
+  volcano-scheduler.conf: |
+    actions: "allocate, preempt, reclaim"
+    tiers:
+    - plugins:
+      - name: priority
+      - name: gang
+        enablePreemptable: false
+    - plugins:
+      - name: drf
+        enablePreemptable: false
+      - name: predicates
+      - name: capacity
+        enableHierarchy: true
+        arguments:
+          ancestorReclaimLevel: 1
+      - name: nodeorder
+```
+
+The value controls how many ancestor levels are checked when Volcano decides whether a running workload from another queue can be reclaimed:
+
+- `0`: keep the default behavior. Volcano does not add ancestor-level reclaim restrictions.
+- `1`: add parent-level deserved-resource checks for cross-parent reclaim.
+- `2`: add grandparent-level checks when the queue topology reaches that level.
+- `N`: continue the same pattern for deeper queue trees.
+
 ### Building Hierarchical Queues
 A new `parent` field has been added to the Queue spec to specify the parent queue:
 
@@ -135,3 +171,117 @@ spec:
 When cluster resources are insufficient for pod requirement, pod's resources can be reclaimed. For pods in different queues, they will first reclaim pods in sibling queues (if the allocated resources of the sibling queue exceed the `deserved` value). If the resources in sibling queues are still insufficient to meet the pod's requirements, the hierarchical structure of the queues (i.e., ancestor queues) will be traversed upward to find sufficient resources. For example, if job-a and job-c are submitted first and the cluster resources are insufficient for job-b, job-b will first reclaim job-a. If reclaiming job-a does not meet the resource requirements, job-c will then be considered for reclaiming.
 
 Note that in the current version, users can only submit jobs to **leaf queues**. If tasks have already been submitted to a parent queue, child queues cannot be created under that queue. This ensures effective management of resources and tasks across different levels in the queue hierarchy. Additionally, the sum of the `deserved`/`guarantee` values of child queues cannot exceed the `deserved`/`guarantee` values configured for the parent queue. Each child queue's `capability` values cannot exceed the `capability` limits of the parent queue. If a queue does not specify the `capability` value for a certain resource dimension, it will inherit the `capability` from its parent queue. If the parent queue and all ancestor queues do not specify it, the value will finally inherit from the root queue. By default, the root queue's `capability` is set to the total available resources of that dimension in the cluster.
+
+### Understanding `ancestorReclaimLevel`
+
+Hierarchical queues allow one part of the queue tree to use unused `deserved` resources from another part of the queue tree. When a queue later has pending work, reclaim can give those borrowed resources back from a reclaimable queue that is over its own `deserved` resources.
+
+`ancestorReclaimLevel` controls how much of the hierarchy must be considered before a queue is treated as a valid reclaim victim. This is useful for any queue tree that encodes ownership, quota boundaries, workload classes, accelerator pools, environments, cost centers, tenants, or any other resource-sharing model.
+
+#### Scenario 1: parent-level reclaim is allowed
+
+In this example, `queue-b` is over its own `deserved` resources and its parent `parent-b` is also over its `deserved` resources. `queue-a` has a pending pod that cannot be scheduled without reclaim.
+
+```mermaid
+graph TD
+  R[root]
+  PA[parent-a<br/>deserved: a100=1<br/>allocated: a100=0]
+  QA[queue-a<br/>deserved: a100=1<br/>pending: p-reclaimer a100=1]
+  PB[parent-b<br/>deserved: a100=3<br/>allocated: a100=4]
+  QB[queue-b<br/>deserved: a100=1<br/>allocated: a100=4<br/>running: p1 a100=1, p2 a100=1, p3 a100=1, p4 a100=1]
+  R --> PA
+  PA --> QA
+  R --> PB
+  PB --> QB
+```
+
+With `ancestorReclaimLevel: 1`, Volcano checks the leaf queue and then the parent level. Because `queue-b` and `parent-b` are both over their relevant `deserved` resources, one running pod from `queue-b` can be reclaimed and the pending pod in `queue-a` can be pipelined.
+
+#### Scenario 2: parent-level reclaim is blocked
+
+Here the leaf queue `queue-b` is over its own `deserved` resources, but its parent is still within its share. That means the parent branch is not borrowing more than it should at the level being protected.
+
+```mermaid
+graph TD
+  R[root]
+  PA[parent-a<br/>deserved: a100=1<br/>allocated: a100=0]
+  QA[queue-a<br/>deserved: a100=1<br/>pending: p-reclaimer a100=1]
+  PB[parent-b<br/>deserved: a100=4<br/>allocated: a100=2]
+  QB[queue-b<br/>deserved: a100=1<br/>allocated: a100=2<br/>running: p1 a100=1, p2 a100=1]
+  R --> PA
+  PA --> QA
+  R --> PB
+  PB --> QB
+```
+
+With `ancestorReclaimLevel: 1`, reclaim from `queue-b` is blocked. The leaf queue is over deserved, but the protected parent-level check fails because `parent-b` is not over deserved.
+
+#### Scenario 3: level 0 keeps the previous permissive behavior
+
+Using the same topology as Scenario 2, `ancestorReclaimLevel: 0` does not add the parent-level gate. Volcano keeps the previous behavior and relies on the existing reclaim checks. If `queue-b` is reclaimable and over its leaf `deserved` resources, the pending pod in `queue-a` can reclaim from `queue-b` even though `parent-b` is not over deserved.
+
+This is the compatibility setting for clusters that already rely on the existing hierarchical reclaim behavior.
+
+#### Scenario 4: grandparent-level checks protect deeper trees
+
+For deeper queue trees, `ancestorReclaimLevel: 2` also evaluates the grandparent level. This is useful when reclaim should respect a boundary above the direct parent.
+
+```mermaid
+graph TD
+  R[root]
+  GA[group-a<br/>deserved: cpu=2, memory=2Gi<br/>allocated: cpu=0, memory=0]
+  PA[parent-a<br/>deserved: cpu=2, memory=2Gi<br/>allocated: cpu=0, memory=0]
+  QA[queue-a<br/>deserved: cpu=2, memory=2Gi<br/>pending: p-reclaimer cpu=2, memory=2Gi]
+  GB[group-b<br/>deserved: cpu=3, memory=3Gi<br/>allocated: cpu=2, memory=2Gi]
+  PB[parent-b<br/>deserved: cpu=1, memory=1Gi<br/>allocated: cpu=2, memory=2Gi]
+  QB[queue-b<br/>deserved: cpu=1, memory=1Gi<br/>allocated: cpu=2, memory=2Gi<br/>running: p-victim cpu=2, memory=2Gi]
+  R --> GA
+  GA --> PA
+  PA --> QA
+  R --> GB
+  GB --> PB
+  PB --> QB
+```
+
+With `ancestorReclaimLevel: 1`, reclaim can pass because the parent-level check for `parent-b` passes. With `ancestorReclaimLevel: 2`, reclaim is blocked because the grandparent-level check for `group-b` fails: `group-b` is not over its `deserved` resources. The running pod in `queue-b` is therefore not a valid reclaim victim for this pending pod.
+
+#### Scenario 5: shared ancestors do not create an extra boundary without a reclaimer signal
+
+For sibling queues, both queues already share the direct parent. The parent is not a boundary between different branches.
+
+```mermaid
+graph TD
+  R[root]
+  P[parent<br/>deserved: cpu=4, memory=4Gi]
+  QA[queue-a<br/>deserved: unset<br/>pending: p-reclaimer cpu=2, memory=2Gi]
+  QB[queue-b<br/>deserved: unset<br/>running: p-victim cpu=2, memory=2Gi]
+  R --> P
+  P --> QA
+  P --> QB
+```
+
+In this case, `ancestorReclaimLevel: 1` does not make the shared parent an additional reclaim gate. However, `queue-a` also has no relevant `deserved` value for the pending pod's requested resources, so the reclaimer queue has no leaf-level deserved signal for reclaim. Volcano can block reclaim to avoid evicting a sibling workload when the pending workload is not tied to a deserved share.
+
+#### Scenario 6: sibling reclaim is allowed when the reclaimer has a deserved signal
+
+This example uses the same shared-parent topology as Scenario 5, but `queue-a` now has a `deserved` value that matches the pending pod's requested resources.
+
+```mermaid
+graph TD
+  R[root]
+  P[parent<br/>deserved: cpu=4, memory=4Gi]
+  QA[queue-a<br/>deserved: cpu=2, memory=2Gi<br/>pending: p-reclaimer cpu=2, memory=2Gi]
+  QB[queue-b<br/>deserved: unset<br/>running: p-victim cpu=2, memory=2Gi]
+  R --> P
+  P --> QA
+  P --> QB
+```
+
+With `ancestorReclaimLevel: 1`, the shared parent still does not add another boundary between the sibling queues. Because the reclaimer queue has a relevant `deserved` signal for the pending pod, Volcano can reclaim the running pod from `queue-b` and pipeline the pending pod in `queue-a`.
+
+#### Choosing a value
+
+- Use `0` when you want compatibility with the previous reclaim behavior and do not need ancestor-level restrictions.
+- Use `1` when the direct parent should be the first protected boundary for cross-parent reclaim.
+- Use `2` or higher when the queue hierarchy has deeper quota boundaries and reclaim should respect those higher levels too.
+- Configure `deserved` on every ancestor level that should participate in reclaim decisions for the relevant resource. Without a relevant `deserved` value, an ancestor cannot provide a meaningful over-quota signal for that resource.


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
/kind documentation

* **What this PR does / why we need it**:
Documents the capacity plugin `ancestorReclaimLevel` argument in the Hierarchical Queue guide.

The update keeps the base scheduler configuration focused on enabling hierarchical queues, adds `ancestorReclaimLevel` only in the dedicated “Configure Ancestor Reclaim Scope” section, and places the detailed “Understanding `ancestorReclaimLevel`” explanation after “Building Hierarchical Queues”. It also adds concrete queue and pod reclaim scenarios with Mermaid diagrams, including explicit `a100=1` requests for the running pods in the A100 examples.

AI assistance was used for drafting and local verification. The final wording and structure needed substantial human steering and review; hajnalmt had to hammer the assistant quite a lot to keep the placement, semantics, and examples aligned with the intended documentation change.

* **Which issue(s) this PR fixes**:
Fixes volcano-sh/website#529

Related: volcano-sh/volcano#5115
