### PR TITLE
docs: fix versioned docs links

### DIFF
--- a/versioned_docs/version-v1.10.0/Concepts/Queue.md
+++ b/versioned_docs/version-v1.10.0/Concepts/Queue.md
@@ -51,7 +51,7 @@ deserved indicates the expected resource amount for all PodGroups in this queue.
 
 > **Note**:
 > 
-> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: [capacity plugin user guide](/docs/UserGuide/user_guide_how_to_use_capacity_plugin)
+> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: [capacity plugin user guide](https://github.com/volcano-sh/volcano/blob/v1.10.0/docs/user-guide/how_to_use_capacity_plugin.md)
 > 2. If the allocated resources of a queue exceed its configured deserved value, the queue cannot reclaim resources from other queues
 
 * weight, *optional*
@@ -78,7 +78,7 @@ priority indicates the priority of this queue. During resource allocation and re
 
 * parent, *optional*
 
-This field is used to configure [hierarchical queues](/docs/KeyFeatures/HierarchicalQueue). parent specifies the parent queue. If parent is not specified, the queue will be set as a child queue of the root queue by default.
+This field is used to configure hierarchical queues. parent specifies the parent queue. If parent is not specified, the queue will be set as a child queue of the root queue by default.
 
 ## Status
 ### Open
@@ -94,6 +94,6 @@ This field is used to configure [hierarchical queues](/docs/KeyFeatures/Hierarch
 #### default Queue
 When Volcano starts, it automatically creates queue `default` whose `weight` is `1`. Subsequent jobs that are not assigned to a queue will be assigned to queue `default`.
 #### root queue
-When Volcano starts, it also creates a queue named root by default. This queue is used when the [hierarchical queue](/docs/KeyFeatures/HierarchicalQueue) feature is enabled, serving as the root queue for all queues, with the default queue being a child queue of the root queue.
+When Volcano starts, it also creates a queue named root by default. This queue is used when the hierarchical queue feature is enabled, serving as the root queue for all queues, with the default queue being a child queue of the root queue.
 
-> For more information on queue usage scenarios, please refer to [Queue Resource Management](/docs/KeyFeatures/QueueResourceManagement)
+> For more information on queue usage scenarios, please refer to Queue Resource Management

--- a/versioned_docs/version-v1.10.0/Concepts/Queue.md
+++ b/versioned_docs/version-v1.10.0/Concepts/Queue.md
@@ -51,7 +51,7 @@ deserved indicates the expected resource amount for all PodGroups in this queue.
 
 > **Note**:
 > 
-> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: [capacity plugin user guide](https://github.com/volcano-sh/volcano/blob/v1.10.0/docs/user-guide/how_to_use_capacity_plugin.md)
+> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: capacity plugin user guide
 > 2. If the allocated resources of a queue exceed its configured deserved value, the queue cannot reclaim resources from other queues
 
 * weight, *optional*

--- a/versioned_docs/version-v1.10.0/Ecosystem/RayOnVolcano.md
+++ b/versioned_docs/version-v1.10.0/Ecosystem/RayOnVolcano.md
@@ -203,4 +203,4 @@ ray job submit --address http://localhost:8265 -- python -c "import ray; ray.ini
 ### Learn More
 
 - For KubeRay integration details, visit the [KubeRay Volcano Scheduler Documentation](https://docs.ray.io/en/latest/cluster/kubernetes/k8s-ecosystem/volcano.html#kuberay-integration-with-volcano)
-- For Volcano Job Ray plugin details, see the [Volcano Ray Plugin Guide](/docs/UserGuide/user_guide_how_to_use_ray_plugin)
+- For Volcano Job Ray plugin details, see the Volcano Ray Plugin Guide

--- a/versioned_docs/version-v1.11.0/Concepts/Queue.md
+++ b/versioned_docs/version-v1.11.0/Concepts/Queue.md
@@ -51,7 +51,7 @@ deserved indicates the expected resource amount for all PodGroups in this queue.
 
 > **Note**:
 > 
-> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: [capacity plugin user guide](/docs/UserGuide/user_guide_how_to_use_capacity_plugin)
+> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: [capacity plugin user guide](https://github.com/volcano-sh/volcano/blob/v1.11.0/docs/user-guide/how_to_use_capacity_plugin.md)
 > 2. If the allocated resources of a queue exceed its configured deserved value, the queue cannot reclaim resources from other queues
 
 * weight, *optional*
@@ -78,7 +78,7 @@ priority indicates the priority of this queue. During resource allocation and re
 
 * parent, *optional*
 
-This field is used to configure [hierarchical queues](/docs/KeyFeatures/HierarchicalQueue). parent specifies the parent queue. If parent is not specified, the queue will be set as a child queue of the root queue by default.
+This field is used to configure [hierarchical queues](../KeyFeatures/HierarchicalQueue.md). parent specifies the parent queue. If parent is not specified, the queue will be set as a child queue of the root queue by default.
 
 ## Status
 ### Open
@@ -94,6 +94,6 @@ This field is used to configure [hierarchical queues](/docs/KeyFeatures/Hierarch
 #### default Queue
 When Volcano starts, it automatically creates queue `default` whose `weight` is `1`. Subsequent jobs that are not assigned to a queue will be assigned to queue `default`.
 #### root queue
-When Volcano starts, it also creates a queue named root by default. This queue is used when the [hierarchical queue](/docs/KeyFeatures/HierarchicalQueue) feature is enabled, serving as the root queue for all queues, with the default queue being a child queue of the root queue.
+When Volcano starts, it also creates a queue named root by default. This queue is used when the [hierarchical queue](../KeyFeatures/HierarchicalQueue.md) feature is enabled, serving as the root queue for all queues, with the default queue being a child queue of the root queue.
 
-> For more information on queue usage scenarios, please refer to [Queue Resource Management](/docs/KeyFeatures/QueueResourceManagement)
+> For more information on queue usage scenarios, please refer to [Queue Resource Management](../KeyFeatures/QueueResourceManagement.md)

--- a/versioned_docs/version-v1.11.0/Concepts/Queue.md
+++ b/versioned_docs/version-v1.11.0/Concepts/Queue.md
@@ -51,7 +51,7 @@ deserved indicates the expected resource amount for all PodGroups in this queue.
 
 > **Note**:
 > 
-> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: [capacity plugin user guide](https://github.com/volcano-sh/volcano/blob/v1.11.0/docs/user-guide/how_to_use_capacity_plugin.md)
+> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: capacity plugin user guide
 > 2. If the allocated resources of a queue exceed its configured deserved value, the queue cannot reclaim resources from other queues
 
 * weight, *optional*

--- a/versioned_docs/version-v1.11.0/Ecosystem/RayOnVolcano.md
+++ b/versioned_docs/version-v1.11.0/Ecosystem/RayOnVolcano.md
@@ -203,4 +203,4 @@ ray job submit --address http://localhost:8265 -- python -c "import ray; ray.ini
 ### Learn More
 
 - For KubeRay integration details, visit the [KubeRay Volcano Scheduler Documentation](https://docs.ray.io/en/latest/cluster/kubernetes/k8s-ecosystem/volcano.html#kuberay-integration-with-volcano)
-- For Volcano Job Ray plugin details, see the [Volcano Ray Plugin Guide](/docs/UserGuide/user_guide_how_to_use_ray_plugin)
+- For Volcano Job Ray plugin details, see the Volcano Ray Plugin Guide

--- a/versioned_docs/version-v1.11.0/Home/Introduction.md
+++ b/versioned_docs/version-v1.11.0/Home/Introduction.md
@@ -20,7 +20,7 @@ Job scheduling and management become increasingly complex and critical for high-
 
 Volcano is designed to cater to these requirements. In addition, Volcano inherits the design of Kubernetes APIs, allowing you to easily run applications that require high-performance computing on Kubernetes.
 ## Features
-### [Unified Scheduling](/docs/KeyFeatures/UnifiedScheduling)
+### [Unified Scheduling](../KeyFeatures/UnifiedScheduling.md)
 * Support native Kubernetes workload scheduling
 * Provide complete support for frameworks like PyTorch, TensorFlow, Spark, Flink, Ray through VolcanoJob
 * Unified scheduling for both online microservices and offline batch jobs to improve cluster resource utilization
@@ -39,7 +39,7 @@ Volcano is designed to cater to these requirements. In addition, Volcano inherit
 
 Volcano supports custom plugins and actions to implement more scheduling algorithms.
 
-### [Queue Resource Management](/docs/KeyFeatures/QueueResourceManagement)
+### [Queue Resource Management](../KeyFeatures/QueueResourceManagement.md)
 * Support multi-dimensional resource quota control (CPU, Memory, GPU, etc.)
 * Provide multi-level queue structure and resource inheritance
 * Support resource borrowing, reclaiming and preemption between queues
@@ -52,7 +52,7 @@ Volcano can schedule computing resources from multiple architectures:
 * Arm
 * Kunpeng
 * Ascend
-* GPU: Supports [GPU virtualization](/docs/v1.11.0/KeyFeatures/GPUVirtualization) functionality, providing fine-grained GPU resource management
+* GPU: Supports [GPU virtualization](../KeyFeatures/GPUVirtualization.md) functionality, providing fine-grained GPU resource management
   * **vGPU Scheduling**: Supports virtualizing single physical GPU into multiple vGPUs for fine-grained GPU resource allocation
   * **Memory Isolation**: Supports setting independent memory limits for each vGPU to prevent memory conflicts between tasks
   * **Compute Allocation**: Supports allocating GPU by percentage for resource sharing

--- a/versioned_docs/version-v1.11.0/KeyFeatures/QueueResourceManagement.md
+++ b/versioned_docs/version-v1.11.0/KeyFeatures/QueueResourceManagement.md
@@ -50,7 +50,7 @@ deserved indicates the expected resource amount for all PodGroups in this queue.
 
 > **Note**:
 > 
-> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: [capacity plugin user guide](/docs/UserGuide/user_guide_how_to_use_capacity_plugin)
+> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: [capacity plugin user guide](https://github.com/volcano-sh/volcano/blob/v1.11.0/docs/user-guide/how_to_use_capacity_plugin.md)
 > 2. If the allocated resources of a queue exceed its configured deserved value, the queue cannot reclaim resources from other queues
 
 * weight, *optional*
@@ -77,7 +77,7 @@ priority indicates the priority of this queue. During resource allocation and re
 
 * parent, *optional*
 
-This field is used to configure [hierarchical queues](/docs/KeyFeatures/HierarchicalQueue). parent specifies the parent queue. If parent is not specified, the queue will be set as a child queue of the root queue by default.
+This field is used to configure [hierarchical queues](HierarchicalQueue.md). parent specifies the parent queue. If parent is not specified, the queue will be set as a child queue of the root queue by default.
 
 ## Status
 ### Open
@@ -93,6 +93,6 @@ This field is used to configure [hierarchical queues](/docs/KeyFeatures/Hierarch
 #### default Queue
 When Volcano starts, it automatically creates queue `default` whose `weight` is `1`. Subsequent jobs that are not assigned to a queue will be assigned to queue `default`.
 #### root queue
-When Volcano starts, it also creates a queue named root by default. This queue is used when the [hierarchical queue](/docs/KeyFeatures/HierarchicalQueue) feature is enabled, serving as the root queue for all queues, with the default queue being a child queue of the root queue.
+When Volcano starts, it also creates a queue named root by default. This queue is used when the [hierarchical queue](HierarchicalQueue.md) feature is enabled, serving as the root queue for all queues, with the default queue being a child queue of the root queue.
 
-> For more information on queue usage scenarios, please refer to [Queue Resource Management](/docs/KeyFeatures/QueueResourceManagement)
+> For more information on queue usage scenarios, please refer to [Queue Resource Management](QueueResourceManagement.md)

--- a/versioned_docs/version-v1.11.0/KeyFeatures/QueueResourceManagement.md
+++ b/versioned_docs/version-v1.11.0/KeyFeatures/QueueResourceManagement.md
@@ -50,7 +50,7 @@ deserved indicates the expected resource amount for all PodGroups in this queue.
 
 > **Note**:
 > 
-> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: [capacity plugin user guide](https://github.com/volcano-sh/volcano/blob/v1.11.0/docs/user-guide/how_to_use_capacity_plugin.md)
+> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: capacity plugin user guide
 > 2. If the allocated resources of a queue exceed its configured deserved value, the queue cannot reclaim resources from other queues
 
 * weight, *optional*

--- a/versioned_docs/version-v1.11.0/KeyFeatures/QueueResourceManagement.md
+++ b/versioned_docs/version-v1.11.0/KeyFeatures/QueueResourceManagement.md
@@ -95,4 +95,4 @@ When Volcano starts, it automatically creates queue `default` whose `weight` is 
 #### root queue
 When Volcano starts, it also creates a queue named root by default. This queue is used when the [hierarchical queue](HierarchicalQueue.md) feature is enabled, serving as the root queue for all queues, with the default queue being a child queue of the root queue.
 
-> For more information on queue usage scenarios, please refer to [Queue Resource Management](QueueResourceManagement.md)
+> For more information on queue usage scenarios, please refer to Queue Resource Management

--- a/versioned_docs/version-v1.12.0/Concepts/Queue.md
+++ b/versioned_docs/version-v1.12.0/Concepts/Queue.md
@@ -51,7 +51,7 @@ deserved indicates the expected resource amount for all PodGroups in this queue.
 
 > **Note**:
 > 
-> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: [capacity plugin user guide](https://github.com/volcano-sh/volcano/blob/v1.12.0/docs/user-guide/how_to_use_capacity_plugin.md)
+> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: capacity plugin user guide
 > 2. If the allocated resources of a queue exceed its configured deserved value, the queue cannot reclaim resources from other queues
 
 * weight, *optional*

--- a/versioned_docs/version-v1.12.0/Concepts/Queue.md
+++ b/versioned_docs/version-v1.12.0/Concepts/Queue.md
@@ -51,7 +51,7 @@ deserved indicates the expected resource amount for all PodGroups in this queue.
 
 > **Note**:
 > 
-> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: [capacity plugin user guide](/docs/UserGuide/user_guide_how_to_use_capacity_plugin)
+> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: [capacity plugin user guide](https://github.com/volcano-sh/volcano/blob/v1.12.0/docs/user-guide/how_to_use_capacity_plugin.md)
 > 2. If the allocated resources of a queue exceed its configured deserved value, the queue cannot reclaim resources from other queues
 
 * weight, *optional*
@@ -78,7 +78,7 @@ priority indicates the priority of this queue. During resource allocation and re
 
 * parent, *optional*
 
-This field is used to configure [hierarchical queues](/docs/KeyFeatures/HierarchicalQueue). parent specifies the parent queue. If parent is not specified, the queue will be set as a child queue of the root queue by default.
+This field is used to configure [hierarchical queues](../KeyFeatures/HierarchicalQueue.md). parent specifies the parent queue. If parent is not specified, the queue will be set as a child queue of the root queue by default.
 
 ## Status
 ### Open
@@ -94,6 +94,6 @@ This field is used to configure [hierarchical queues](/docs/KeyFeatures/Hierarch
 #### default Queue
 When Volcano starts, it automatically creates queue `default` whose `weight` is `1`. Subsequent jobs that are not assigned to a queue will be assigned to queue `default`.
 #### root queue
-When Volcano starts, it also creates a queue named root by default. This queue is used when the [hierarchical queue](/docs/KeyFeatures/HierarchicalQueue) feature is enabled, serving as the root queue for all queues, with the default queue being a child queue of the root queue.
+When Volcano starts, it also creates a queue named root by default. This queue is used when the [hierarchical queue](../KeyFeatures/HierarchicalQueue.md) feature is enabled, serving as the root queue for all queues, with the default queue being a child queue of the root queue.
 
-> For more information on queue usage scenarios, please refer to [Queue Resource Management](/docs/KeyFeatures/QueueResourceManagement)
+> For more information on queue usage scenarios, please refer to [Queue Resource Management](../KeyFeatures/QueueResourceManagement.md)

--- a/versioned_docs/version-v1.12.0/Ecosystem/RayOnVolcano.md
+++ b/versioned_docs/version-v1.12.0/Ecosystem/RayOnVolcano.md
@@ -203,4 +203,4 @@ ray job submit --address http://localhost:8265 -- python -c "import ray; ray.ini
 ### Learn More
 
 - For KubeRay integration details, visit the [KubeRay Volcano Scheduler Documentation](https://docs.ray.io/en/latest/cluster/kubernetes/k8s-ecosystem/volcano.html#kuberay-integration-with-volcano)
-- For Volcano Job Ray plugin details, see the [Volcano Ray Plugin Guide](/docs/UserGuide/user_guide_how_to_use_ray_plugin)
+- For Volcano Job Ray plugin details, see the Volcano Ray Plugin Guide

--- a/versioned_docs/version-v1.12.0/Home/Introduction.md
+++ b/versioned_docs/version-v1.12.0/Home/Introduction.md
@@ -20,7 +20,7 @@ Job scheduling and management become increasingly complex and critical for high-
 
 Volcano is designed to cater to these requirements. In addition, Volcano inherits the design of Kubernetes APIs, allowing you to easily run applications that require high-performance computing on Kubernetes.
 ## Features
-### [Unified Scheduling](/docs/KeyFeatures/UnifiedScheduling)
+### [Unified Scheduling](../KeyFeatures/UnifiedScheduling.md)
 * Support native Kubernetes workload scheduling
 * Provide complete support for frameworks like PyTorch, TensorFlow, Spark, Flink, Ray through VolcanoJob
 * Unified scheduling for both online microservices and offline batch jobs to improve cluster resource utilization
@@ -39,7 +39,7 @@ Volcano is designed to cater to these requirements. In addition, Volcano inherit
 
 Volcano supports custom plugins and actions to implement more scheduling algorithms.
 
-### [Queue Resource Management](/docs/KeyFeatures/QueueResourceManagement)
+### [Queue Resource Management](../KeyFeatures/QueueResourceManagement.md)
 * Support multi-dimensional resource quota control (CPU, Memory, GPU, etc.)
 * Provide multi-level queue structure and resource inheritance
 * Support resource borrowing, reclaiming and preemption between queues
@@ -52,7 +52,7 @@ Volcano can schedule computing resources from multiple architectures:
 * Arm
 * Kunpeng
 * Ascend
-* GPU: Supports multiple [GPU virtualization](/docs/KeyFeatures/GPUVirtualization) technologies for flexible resource management
+* GPU: Supports multiple [GPU virtualization](../KeyFeatures/GPUVirtualization.md) technologies for flexible resource management
   * **Dynamic MIG Support**: Enables dynamic partitioning of NVIDIA Multi-Instance GPUs (MIG), providing hardware-level isolation to segment a physical GPU into multiple independent instances
   * **vCUDA Virtualization**: Virtualizes physical GPUs into multiple vGPU devices at the software level for resource sharing and isolation
   * **Fine-Grained Resource Control**: Provides dedicated memory and compute allocation for each GPU instance

--- a/versioned_docs/version-v1.12.0/KeyFeatures/QueueResourceManagement.md
+++ b/versioned_docs/version-v1.12.0/KeyFeatures/QueueResourceManagement.md
@@ -50,7 +50,7 @@ deserved indicates the expected resource amount for all PodGroups in this queue.
 
 > **Note**:
 > 
-> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: [capacity plugin user guide](/docs/UserGuide/user_guide_how_to_use_capacity_plugin)
+> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: [capacity plugin user guide](https://github.com/volcano-sh/volcano/blob/v1.12.0/docs/user-guide/how_to_use_capacity_plugin.md)
 > 2. If the allocated resources of a queue exceed its configured deserved value, the queue cannot reclaim resources from other queues
 
 * weight, *optional*
@@ -77,7 +77,7 @@ priority indicates the priority of this queue. During resource allocation and re
 
 * parent, *optional*
 
-This field is used to configure [hierarchical queues](/docs/KeyFeatures/HierarchicalQueue). parent specifies the parent queue. If parent is not specified, the queue will be set as a child queue of the root queue by default.
+This field is used to configure [hierarchical queues](HierarchicalQueue.md). parent specifies the parent queue. If parent is not specified, the queue will be set as a child queue of the root queue by default.
 
 ## Status
 ### Open
@@ -93,6 +93,6 @@ This field is used to configure [hierarchical queues](/docs/KeyFeatures/Hierarch
 #### default Queue
 When Volcano starts, it automatically creates queue `default` whose `weight` is `1`. Subsequent jobs that are not assigned to a queue will be assigned to queue `default`.
 #### root queue
-When Volcano starts, it also creates a queue named root by default. This queue is used when the [hierarchical queue](/docs/KeyFeatures/HierarchicalQueue) feature is enabled, serving as the root queue for all queues, with the default queue being a child queue of the root queue.
+When Volcano starts, it also creates a queue named root by default. This queue is used when the [hierarchical queue](HierarchicalQueue.md) feature is enabled, serving as the root queue for all queues, with the default queue being a child queue of the root queue.
 
-> For more information on queue usage scenarios, please refer to [Queue Resource Management](/docs/KeyFeatures/QueueResourceManagement)
+> For more information on queue usage scenarios, please refer to [Queue Resource Management](QueueResourceManagement.md)

--- a/versioned_docs/version-v1.12.0/KeyFeatures/QueueResourceManagement.md
+++ b/versioned_docs/version-v1.12.0/KeyFeatures/QueueResourceManagement.md
@@ -50,7 +50,7 @@ deserved indicates the expected resource amount for all PodGroups in this queue.
 
 > **Note**:
 > 
-> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: [capacity plugin user guide](https://github.com/volcano-sh/volcano/blob/v1.12.0/docs/user-guide/how_to_use_capacity_plugin.md)
+> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: capacity plugin user guide
 > 2. If the allocated resources of a queue exceed its configured deserved value, the queue cannot reclaim resources from other queues
 
 * weight, *optional*

--- a/versioned_docs/version-v1.12.0/KeyFeatures/QueueResourceManagement.md
+++ b/versioned_docs/version-v1.12.0/KeyFeatures/QueueResourceManagement.md
@@ -95,4 +95,4 @@ When Volcano starts, it automatically creates queue `default` whose `weight` is 
 #### root queue
 When Volcano starts, it also creates a queue named root by default. This queue is used when the [hierarchical queue](HierarchicalQueue.md) feature is enabled, serving as the root queue for all queues, with the default queue being a child queue of the root queue.
 
-> For more information on queue usage scenarios, please refer to [Queue Resource Management](QueueResourceManagement.md)
+> For more information on queue usage scenarios, please refer to Queue Resource Management

--- a/versioned_docs/version-v1.7.0/Concepts/Queue.md
+++ b/versioned_docs/version-v1.7.0/Concepts/Queue.md
@@ -51,7 +51,7 @@ deserved indicates the expected resource amount for all PodGroups in this queue.
 
 > **Note**:
 > 
-> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: [capacity plugin user guide](/docs/UserGuide/user_guide_how_to_use_capacity_plugin)
+> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: capacity plugin user guide
 > 2. If the allocated resources of a queue exceed its configured deserved value, the queue cannot reclaim resources from other queues
 
 * weight, *optional*
@@ -78,7 +78,7 @@ priority indicates the priority of this queue. During resource allocation and re
 
 * parent, *optional*
 
-This field is used to configure [hierarchical queues](/docs/KeyFeatures/HierarchicalQueue). parent specifies the parent queue. If parent is not specified, the queue will be set as a child queue of the root queue by default.
+This field is used to configure hierarchical queues. parent specifies the parent queue. If parent is not specified, the queue will be set as a child queue of the root queue by default.
 
 ## Status
 ### Open
@@ -94,6 +94,6 @@ This field is used to configure [hierarchical queues](/docs/KeyFeatures/Hierarch
 #### default Queue
 When Volcano starts, it automatically creates queue `default` whose `weight` is `1`. Subsequent jobs that are not assigned to a queue will be assigned to queue `default`.
 #### root queue
-When Volcano starts, it also creates a queue named root by default. This queue is used when the [hierarchical queue](/docs/KeyFeatures/HierarchicalQueue) feature is enabled, serving as the root queue for all queues, with the default queue being a child queue of the root queue.
+When Volcano starts, it also creates a queue named root by default. This queue is used when the hierarchical queue feature is enabled, serving as the root queue for all queues, with the default queue being a child queue of the root queue.
 
-> For more information on queue usage scenarios, please refer to [Queue Resource Management](/docs/KeyFeatures/QueueResourceManagement)
+> For more information on queue usage scenarios, please refer to Queue Resource Management

--- a/versioned_docs/version-v1.7.0/Ecosystem/RayOnVolcano.md
+++ b/versioned_docs/version-v1.7.0/Ecosystem/RayOnVolcano.md
@@ -203,4 +203,4 @@ ray job submit --address http://localhost:8265 -- python -c "import ray; ray.ini
 ### Learn More
 
 - For KubeRay integration details, visit the [KubeRay Volcano Scheduler Documentation](https://docs.ray.io/en/latest/cluster/kubernetes/k8s-ecosystem/volcano.html#kuberay-integration-with-volcano)
-- For Volcano Job Ray plugin details, see the [Volcano Ray Plugin Guide](/docs/UserGuide/user_guide_how_to_use_ray_plugin)
+- For Volcano Job Ray plugin details, see the Volcano Ray Plugin Guide

--- a/versioned_docs/version-v1.8.2/Concepts/Queue.md
+++ b/versioned_docs/version-v1.8.2/Concepts/Queue.md
@@ -51,7 +51,7 @@ deserved indicates the expected resource amount for all PodGroups in this queue.
 
 > **Note**:
 > 
-> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: [capacity plugin user guide](/docs/UserGuide/user_guide_how_to_use_capacity_plugin)
+> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: capacity plugin user guide
 > 2. If the allocated resources of a queue exceed its configured deserved value, the queue cannot reclaim resources from other queues
 
 * weight, *optional*
@@ -78,7 +78,7 @@ priority indicates the priority of this queue. During resource allocation and re
 
 * parent, *optional*
 
-This field is used to configure [hierarchical queues](/docs/KeyFeatures/HierarchicalQueue). parent specifies the parent queue. If parent is not specified, the queue will be set as a child queue of the root queue by default.
+This field is used to configure hierarchical queues. parent specifies the parent queue. If parent is not specified, the queue will be set as a child queue of the root queue by default.
 
 ## Status
 ### Open
@@ -94,6 +94,6 @@ This field is used to configure [hierarchical queues](/docs/KeyFeatures/Hierarch
 #### default Queue
 When Volcano starts, it automatically creates queue `default` whose `weight` is `1`. Subsequent jobs that are not assigned to a queue will be assigned to queue `default`.
 #### root queue
-When Volcano starts, it also creates a queue named root by default. This queue is used when the [hierarchical queue](/docs/KeyFeatures/HierarchicalQueue) feature is enabled, serving as the root queue for all queues, with the default queue being a child queue of the root queue.
+When Volcano starts, it also creates a queue named root by default. This queue is used when the hierarchical queue feature is enabled, serving as the root queue for all queues, with the default queue being a child queue of the root queue.
 
-> For more information on queue usage scenarios, please refer to [Queue Resource Management](/docs/KeyFeatures/QueueResourceManagement)
+> For more information on queue usage scenarios, please refer to Queue Resource Management

--- a/versioned_docs/version-v1.8.2/Ecosystem/RayOnVolcano.md
+++ b/versioned_docs/version-v1.8.2/Ecosystem/RayOnVolcano.md
@@ -203,4 +203,4 @@ ray job submit --address http://localhost:8265 -- python -c "import ray; ray.ini
 ### Learn More
 
 - For KubeRay integration details, visit the [KubeRay Volcano Scheduler Documentation](https://docs.ray.io/en/latest/cluster/kubernetes/k8s-ecosystem/volcano.html#kuberay-integration-with-volcano)
-- For Volcano Job Ray plugin details, see the [Volcano Ray Plugin Guide](/docs/UserGuide/user_guide_how_to_use_ray_plugin)
+- For Volcano Job Ray plugin details, see the Volcano Ray Plugin Guide

--- a/versioned_docs/version-v1.9.0/Concepts/Queue.md
+++ b/versioned_docs/version-v1.9.0/Concepts/Queue.md
@@ -51,7 +51,7 @@ deserved indicates the expected resource amount for all PodGroups in this queue.
 
 > **Note**:
 > 
-> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: [capacity plugin user guide](https://github.com/volcano-sh/volcano/blob/v1.9.0/docs/user-guide/how_to_use_capacity_plugin.md)
+> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: capacity plugin user guide
 > 2. If the allocated resources of a queue exceed its configured deserved value, the queue cannot reclaim resources from other queues
 
 * weight, *optional*

--- a/versioned_docs/version-v1.9.0/Concepts/Queue.md
+++ b/versioned_docs/version-v1.9.0/Concepts/Queue.md
@@ -51,7 +51,7 @@ deserved indicates the expected resource amount for all PodGroups in this queue.
 
 > **Note**:
 > 
-> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: [capacity plugin user guide](/docs/UserGuide/user_guide_how_to_use_capacity_plugin)
+> 1. This field can only be configured when the capacity plugin is enabled, and must be less than or equal to the capability value. The proportion plugin uses weight to automatically calculate the queue's deserved value. For more information on using the capacity plugin, see: [capacity plugin user guide](https://github.com/volcano-sh/volcano/blob/v1.9.0/docs/user-guide/how_to_use_capacity_plugin.md)
 > 2. If the allocated resources of a queue exceed its configured deserved value, the queue cannot reclaim resources from other queues
 
 * weight, *optional*
@@ -78,7 +78,7 @@ priority indicates the priority of this queue. During resource allocation and re
 
 * parent, *optional*
 
-This field is used to configure [hierarchical queues](/docs/KeyFeatures/HierarchicalQueue). parent specifies the parent queue. If parent is not specified, the queue will be set as a child queue of the root queue by default.
+This field is used to configure hierarchical queues. parent specifies the parent queue. If parent is not specified, the queue will be set as a child queue of the root queue by default.
 
 ## Status
 ### Open
@@ -94,6 +94,6 @@ This field is used to configure [hierarchical queues](/docs/KeyFeatures/Hierarch
 #### default Queue
 When Volcano starts, it automatically creates queue `default` whose `weight` is `1`. Subsequent jobs that are not assigned to a queue will be assigned to queue `default`.
 #### root queue
-When Volcano starts, it also creates a queue named root by default. This queue is used when the [hierarchical queue](/docs/KeyFeatures/HierarchicalQueue) feature is enabled, serving as the root queue for all queues, with the default queue being a child queue of the root queue.
+When Volcano starts, it also creates a queue named root by default. This queue is used when the hierarchical queue feature is enabled, serving as the root queue for all queues, with the default queue being a child queue of the root queue.
 
-> For more information on queue usage scenarios, please refer to [Queue Resource Management](/docs/KeyFeatures/QueueResourceManagement)
+> For more information on queue usage scenarios, please refer to Queue Resource Management

--- a/versioned_docs/version-v1.9.0/Ecosystem/RayOnVolcano.md
+++ b/versioned_docs/version-v1.9.0/Ecosystem/RayOnVolcano.md
@@ -203,4 +203,4 @@ ray job submit --address http://localhost:8265 -- python -c "import ray; ray.ini
 ### Learn More
 
 - For KubeRay integration details, visit the [KubeRay Volcano Scheduler Documentation](https://docs.ray.io/en/latest/cluster/kubernetes/k8s-ecosystem/volcano.html#kuberay-integration-with-volcano)
-- For Volcano Job Ray plugin details, see the [Volcano Ray Plugin Guide](/docs/UserGuide/user_guide_how_to_use_ray_plugin)
+- For Volcano Job Ray plugin details, see the Volcano Ray Plugin Guide


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
/kind documentation
/kind bug

* **What this PR does / why we need it**:

Fixes stale links in older versioned docs that pointed to `/docs/...`.

Those links send users back to Latest docs instead of keeping them in the selected version. Existing same-version pages now use relative links. Links with no matching page in that old version are left as plain text.

* **Which issue(s) this PR fixes**:

Fixes #536