### PR TITLE
fix: replace incorrect @ symbol with © in footer copyright

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -181,7 +181,7 @@ const config = {
             <img class="footer__logo" alt="Cloud Native Computing Foundation Logo" src="/img/landing/logo_cloudnative.png" />
           </div>
           <p>The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage" target="_blank" rel="noopener noreferrer">Trademark Usage</a> page.</p>
-          <p>${new Date().getFullYear()} @ Volcano Project Authors. All rights reserved.</p>
+          <p>© ${new Date().getFullYear()} Volcano Project Authors. All rights reserved.</p>
       `,
     },
     prism: {

--- a/i18n/zh-Hans/docusaurus-theme-classic/footer.json
+++ b/i18n/zh-Hans/docusaurus-theme-classic/footer.json
@@ -1,6 +1,6 @@
 {
   "copyright": {
-    "message": "\n        <div class=\"footer-content\">\n          <p>Volcano是 <a href=\"https://www.cncf.io/\" target=\"_blank\" rel=\"noopener noreferrer\">云原生计算基金会</a> 孵化项目</p>\n          <div class=\"footer__logo-container\">\n            <img class=\"footer__logo\" alt=\"云原生计算基金会徽标\" src=\"/img/landing/logo_cloudnative.png\" />\n          </div>\n          <p>Linux基金会已注册并使用其商标。有关Linux基金会的商标列表，请参见 <a href=\"https://www.linuxfoundation.org/trademark-usage\" target=\"_blank\" rel=\"noopener noreferrer\">商标使用</a> 页面。</p>\n          <p>版权所有©2025 @ Volcano 项目作者所有。保留一切权利。</p>\n      ",
+    "message": "\n        <div class=\"footer-content\">\n          <p>Volcano是 <a href=\"https://www.cncf.io/\" target=\"_blank\" rel=\"noopener noreferrer\">云原生计算基金会</a> 孵化项目</p>\n          <div class=\"footer__logo-container\">\n            <img class=\"footer__logo\" alt=\"云原生计算基金会徽标\" src=\"/img/landing/logo_cloudnative.png\" />\n          </div>\n          <p>Linux基金会已注册并使用其商标。有关Linux基金会的商标列表，请参见 <a href=\"https://www.linuxfoundation.org/trademark-usage\" target=\"_blank\" rel=\"noopener noreferrer\">商标使用</a> 页面。</p>\n          <p>版权所有 © 2025 Volcano 项目作者所有。保留一切权利。</p>\n      ",
     "description": "The footer copyright"
   }
 }


### PR DESCRIPTION
## Description

The footer on both the English and Chinese pages used `@` instead of the standard copyright symbol `©`. This PR replaces the incorrect symbol with `©` in both `docusaurus.config.js` and `i18n/zh-Hans/docusaurus-theme-classic/footer.json`.

Additionally, the Chinese footer contained both `©` and `@` (`©2025 @`), resulting in duplicate copyright symbols. This has been corrected so the footer uses a single, standard copyright symbol.

---

### **Please check if the PR fulfills these requirements**

* [x] The commit message follows our guidelines

---

### **What kind of change does this PR introduce?**

/kind bug

---

### **What this PR does / why we need it**

* Replaces the incorrect `@` symbol with the standard copyright symbol `©` in the English footer.
* Fixes the Chinese footer by removing the duplicate `@` symbol and ensuring only `©` is used.
* Makes the footer copyright text consistent across locales.

---

### **Which issue(s) this PR fixes**

Fixes #538
