### PR TITLE
docs: document nodegroup resource limits

### DIFF
--- a/docs/UserGuide/user_guide_how_to_use_nodegroup_plugin.md
+++ b/docs/UserGuide/user_guide_how_to_use_nodegroup_plugin.md
@@ -44,7 +44,7 @@ metadata:
 
 ### Configure queue resource limits for each nodegroup
 
-Use the `volcano.sh/nodegroup-resource-limits` annotation to limit how many resources a queue can allocate from each nodegroup.
+Use the `volcano.sh/nodegroup-resource-limits` annotation to limit the amount of resources a queue can allocate from each nodegroup.
 
 ```yaml
 apiVersion: scheduling.volcano.sh/v1beta1
@@ -75,7 +75,7 @@ For a task from queue `Q` scheduled to a node in nodegroup `G`, the plugin check
 allocated(Q, G) + task request <= limit(Q, G)
 ```
 
-If the future usage exceeds the configured limit, the node is rejected for that task. Other allowed nodegroups remain schedulable, so the queue can prefer `groupname1` and overflow to `groupname2` when the logical limit for `groupname1` is reached.
+If the resulting resource usage exceeds the configured limit, the node is rejected for that task. Other allowed nodegroups remain schedulable, so the queue can prefer `groupname1` and overflow to `groupname2` when the logical limit for `groupname1` is reached.
 
 Only resource dimensions explicitly listed for a nodegroup are limited. For example, `{"groupname2": {"cpu": "50"}}` limits CPU usage in `groupname2` and does not add a memory limit for that nodegroup.
 

--- a/docs/UserGuide/user_guide_how_to_use_nodegroup_plugin.md
+++ b/docs/UserGuide/user_guide_how_to_use_nodegroup_plugin.md
@@ -42,6 +42,47 @@ metadata:
           - <groupname>
 ```
 
+### Configure queue resource limits for each nodegroup
+
+Use the `volcano.sh/nodegroup-resource-limits` annotation to limit how many resources a queue can allocate from each nodegroup.
+
+```yaml
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: Queue
+metadata:
+  name: default
+  annotations:
+    volcano.sh/nodegroup-resource-limits: |
+      {
+        "groupname1": {"cpu": "100", "memory": "200Gi"},
+        "groupname2": {"cpu": "50"}
+      }
+spec:
+  reclaimable: true
+  weight: 1
+  affinity:
+    nodeGroupAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - groupname1
+        - groupname2
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - groupname1
+```
+
+For a task from queue `Q` scheduled to a node in nodegroup `G`, the plugin checks:
+
+```text
+allocated(Q, G) + task request <= limit(Q, G)
+```
+
+If the future usage exceeds the configured limit, the node is rejected for that task. Other allowed nodegroups remain schedulable, so the queue can prefer `groupname1` and overflow to `groupname2` when the logical limit for `groupname1` is reached.
+
+Only resource dimensions explicitly listed for a nodegroup are limited. For example, `{"groupname2": {"cpu": "50"}}` limits CPU usage in `groupname2` and does not add a memory limit for that nodegroup.
+
+If this annotation is absent, existing nodegroup behavior is unchanged. If a nodegroup is not listed in the annotation, that nodegroup has no extra limit from this feature.
+
+The annotation is not inherited by child queues when hierarchical nodegroup affinity is enabled. Each queue that needs per-nodegroup limits must define its own annotation.
+
 ### submit a vcjob
 
 submit vcjob job-1 to default queue.

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/UserGuide/user_guide_how_to_use_nodegroup_plugin.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/UserGuide/user_guide_how_to_use_nodegroup_plugin.md
@@ -42,6 +42,47 @@ metadata:
           - <groupname>
 ```
 
+### 为每个 NodeGroup 配置 Queue 资源上限
+
+使用 `volcano.sh/nodegroup-resource-limits` 注解限制 Queue 最多可从各个 NodeGroup 分配多少资源。
+
+```yaml
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: Queue
+metadata:
+  name: default
+  annotations:
+    volcano.sh/nodegroup-resource-limits: |
+      {
+        "groupname1": {"cpu": "100", "memory": "200Gi"},
+        "groupname2": {"cpu": "50"}
+      }
+spec:
+  reclaimable: true
+  weight: 1
+  affinity:
+    nodeGroupAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - groupname1
+        - groupname2
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - groupname1
+```
+
+当 Queue `Q` 中的任务要调度到 NodeGroup `G` 中的节点时，插件会进行以下检查：
+
+```text
+allocated(Q, G) + task request <= limit(Q, G)
+```
+
+如果调度后的资源用量超过配置的上限，插件会拒绝将该任务调度到此节点。其他允许使用的 NodeGroup 仍可参与调度，因此 Queue 可以优先使用 `groupname1`，并在达到 `groupname1` 的逻辑资源上限后将任务调度到 `groupname2`。
+
+只有为 NodeGroup 显式列出的资源维度会受到限制。例如，`{"groupname2": {"cpu": "50"}}` 仅限制 `groupname2` 中的 CPU 用量，不会为该 NodeGroup 添加内存上限。
+
+如果未配置此注解，NodeGroup 的现有行为保持不变。如果注解中未列出某个 NodeGroup，此功能不会对该 NodeGroup 添加额外限制。
+
+启用层级 NodeGroup 亲和性时，子 Queue 不会继承此注解。每个需要 NodeGroup 资源上限的 Queue 都必须单独定义该注解。
+
 ### 提交 Volcano Job
 
 将名为 job-1 的 Volcano Job 提交到 default Queue。

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/UserGuide/user_guide_how_to_use_nodegroup_plugin.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/UserGuide/user_guide_how_to_use_nodegroup_plugin.md
@@ -44,7 +44,7 @@ metadata:
 
 ### 为每个 NodeGroup 配置 Queue 资源上限
 
-使用 `volcano.sh/nodegroup-resource-limits` 注解限制 Queue 最多可从各个 NodeGroup 分配多少资源。
+使用 `volcano.sh/nodegroup-resource-limits` 注解限制 Queue 最多可从各个 NodeGroup 分配的资源量。
 
 ```yaml
 apiVersion: scheduling.volcano.sh/v1beta1
@@ -75,7 +75,7 @@ spec:
 allocated(Q, G) + task request <= limit(Q, G)
 ```
 
-如果调度后的资源用量超过配置的上限，插件会拒绝将该任务调度到此节点。其他允许使用的 NodeGroup 仍可参与调度，因此 Queue 可以优先使用 `groupname1`，并在达到 `groupname1` 的逻辑资源上限后将任务调度到 `groupname2`。
+如果调度后的累计资源用量超过配置的上限，插件会拒绝将该任务调度到此节点。其他允许使用的 NodeGroup 仍可参与调度，因此 Queue 可以优先使用 `groupname1`，并在达到 `groupname1` 的逻辑资源上限后将任务调度到 `groupname2`。
 
 只有为 NodeGroup 显式列出的资源维度会受到限制。例如，`{"groupname2": {"cpu": "50"}}` 仅限制 `groupname2` 中的 CPU 用量，不会为该 NodeGroup 添加内存上限。
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines

* **What kind of change does this PR introduce?**

/kind documentation

* **What this PR does / why we need it**:

Documents the per-queue, per-nodegroup resource limits introduced by volcano-sh/volcano#5461.

- Adds the `volcano.sh/nodegroup-resource-limits` annotation format and a complete Queue example.
- Explains limit enforcement, fallback scheduling, explicit resource dimensions, absent annotation behavior, and hierarchical Queue semantics.
- Updates both the English guide and the current Simplified Chinese translation.

Validation:
- `git diff --check`
- `npm run build`

* **Which issue(s) this PR fixes**:

Related to volcano-sh/volcano#5461