### PR TITLE
docs: fix run-together sentences and punctuation spacing

### DIFF
--- a/docs/Concepts/Queue.md
+++ b/docs/Concepts/Queue.md
@@ -66,7 +66,7 @@ deserved indicates the expected resource amount for all PodGroups in this queue.
 
 * capability, *optional*
 
-`capability` indicates the upper limit of resources the queue can use. It is a hard constraint.If this field is not set, the queue's capability will be set to realCapability (total cluster resources minus the total guarantee values of other queues).
+`capability` indicates the upper limit of resources the queue can use. It is a hard constraint. If this field is not set, the queue's capability will be set to realCapability (total cluster resources minus the total guarantee values of other queues).
 
 * reclaimable, *optional*
 

--- a/docs/Ecosystem/FlinkOnVolcano.md
+++ b/docs/Ecosystem/FlinkOnVolcano.md
@@ -51,7 +51,7 @@ $ tail log/flink-*-taskexecutor-*.out
 
 ##### 1. The deployment of the component
 
-Deploying a Flink Cluster requires creating two deploys, a Service, and a ConfigMap. The scheduling strategy is Volcano.The contents of `flink-configuration-configmap.yaml` are shown below.
+Deploying a Flink Cluster requires creating two deploys, a Service, and a ConfigMap. The scheduling strategy is Volcano. The contents of `flink-configuration-configmap.yaml` are shown below.
 
 ```
 apiVersion: v1
@@ -118,7 +118,7 @@ data:
     logger.netty.level = OFF
 ```
 
-Service is used to provide services for the REST and UI ports of the JobManager.The contents of `jobManager-Service.yaml` are as follows.
+Service is used to provide services for the REST and UI ports of the JobManager. The contents of `jobManager-Service.yaml` are as follows.
 
 ```
 apiVersion: v1
@@ -263,4 +263,4 @@ Once the Flink payload is created, you need to publish the service externally。
 - If you use Huawei Cloud CCE for testing, go to the "Workloads - Stateless Loads" page of CCE. Select Flink-JobManager and click Access Mode.
 - Click "Add Service", select node access, and enter container port bit 8081.
 - Click Network Management in CCE, you can see the service we just added, and visit the link for external publication.
-- Go to the Dashboard page of Flink and click Submit New Job to submit the task. Here you have the option to submit an officially-provided WordCount sample.The directory is `flink-1.12.2/examples/streaming/WordCount.jar`
+- Go to the Dashboard page of Flink and click Submit New Job to submit the task. Here you have the option to submit an officially-provided WordCount sample. The directory is `flink-1.12.2/examples/streaming/WordCount.jar`

--- a/docs/Ecosystem/PaddlePaddleOnVolcano.md
+++ b/docs/Ecosystem/PaddlePaddleOnVolcano.md
@@ -208,7 +208,7 @@ Deploy under the cluster terminal.
 kubectl apply -f ctr-volcano.yaml
 ```
 
-Query if the job is running properly.If the PodGroup cannot meet the scheduling conditions, check that the cluster has sufficient resources available.
+Query if the job is running properly. If the PodGroup cannot meet the scheduling conditions, check that the cluster has sufficient resources available.
 
 ```
 kubectl get podgroup

--- a/docs/GettingStarted/Installation.md
+++ b/docs/GettingStarted/Installation.md
@@ -28,7 +28,7 @@ You can also replace `master` of above url with specific tag/branch (such as `re
 
 ### Install from code
 
-If you don't have a Kubernetes cluster, try one-click install from code base.This way is only available for x86_64 temporarily.
+If you don't have a Kubernetes cluster, try one-click install from code base. This way is only available for x86_64 temporarily.
 
 ```
 git clone https://github.com/volcano-sh/volcano.git

--- a/docs/Scheduler/Actions.md
+++ b/docs/Scheduler/Actions.md
@@ -42,7 +42,7 @@ In a cluster, besides workloads that require explicit resource requests, there a
 
 #### Overview
 
-The preempt action is used for resource preemption between jobs in a queue , or between tasks in a job.The preempt action is a preemption step in the scheduling process, which is used to deal with high-priority scheduling problems. It is used for preemption between jobs in the same queue, or between tasks under the same job.
+The preempt action is used for resource preemption between jobs in a queue, or between tasks in a job. The preempt action is a preemption step in the scheduling process, which is used to deal with high-priority scheduling problems. It is used for preemption between jobs in the same queue, or between tasks under the same job.
 
 #### Scenario
 

--- a/docs/Scheduler/Plugins/predicates.md
+++ b/docs/Scheduler/Plugins/predicates.md
@@ -1,5 +1,5 @@
 ---
-title : "Predicates"
+title: "Predicates"
 ---
 ## Overview
 

--- a/docs/UserGuide/user_guide_how_to_use_extender.md
+++ b/docs/UserGuide/user_guide_how_to_use_extender.md
@@ -53,4 +53,4 @@ data:
 ```
 
 ### Verify Extender is working
-  The user can see in the log something like : `Initialize extender plugin with configuration : {your configuration}`
+  The user can see in the log something like: `Initialize extender plugin with configuration : {your configuration}`

--- a/docs/UserGuide/user_guide_how_to_use_nodegroup_plugin.md
+++ b/docs/UserGuide/user_guide_how_to_use_nodegroup_plugin.md
@@ -209,7 +209,7 @@ spec:
 
 ## How the Nodegroup Plugin Works
 
-The nodegroup design document provides the most detailed information about the node group. There are some tips to help avoid certain issues.These tips are based on a four-nodes cluster and vcjob called job-1:
+The nodegroup design document provides the most detailed information about the node group. There are some tips to help avoid certain issues. These tips are based on a four-node cluster and vcjob called job-1:
 
 | Node  | Label      |
 | ----- | ---------- |

--- a/docs/UserGuide/user_guide_how_to_use_ssh_plugin.md
+++ b/docs/UserGuide/user_guide_how_to_use_ssh_plugin.md
@@ -5,7 +5,7 @@ title: "Volcano Job Plugin -- SSH User Guide"
 
 
 ## Background
-**SSH Plugin** is designed for the login without password for pods within a volcano job , which is necessary for workloads 
+**SSH Plugin** is designed for the login without password for pods within a volcano job, which is necessary for workloads 
 such as [MPI](https://www.open-mpi.org/). It often works with `SVC` plugin.
 
 ## Key Points


### PR DESCRIPTION
* **What kind of change does this PR introduce?**

/kind documentation

* **What this PR does / why we need it**:

Fixes run-together sentences (missing space after a period) and a few stray spaces before punctuation across the docs. These currently render as joined words on the site, e.g. "constraint.If" and "Volcano.The". Text-only, no content changes.

I used an AI assistant to scan the docs and surface these spacing issues, and reviewed every change by hand.

* **Which issue(s) this PR fixes**:

Fixes #549
