### PR TITLE
Volcano_logo not showing in blogs page bug resolved 

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -1,7 +1,7 @@
 volcano:
   name: Volcano
   url: https://volcano.sh
-  image_url: https://volcano.sh/img/volcano_logo.svg
+  image_url: https://volcano.sh/img/blog/volcano_logo.svg
 
 yi-guo:
   name: Yi Guo

--- a/i18n/zh-Hans/docusaurus-plugin-content-blog/authors.yml
+++ b/i18n/zh-Hans/docusaurus-plugin-content-blog/authors.yml
@@ -1,7 +1,7 @@
 volcano:
   name: Volcano
   url: https://volcano.sh
-  image_url: https://volcano.sh/img/volcano_logo.svg
+  image_url: https://volcano.sh/img/blog/volcano_logo.svg
 
 yi-guo:
   name: Yi Guo


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
/kind bug


* **What this PR does / why we need it**:
* This PR fixes a critical bug of Volcano_logo.svg Not found error in blogs pages. I have corrected the img path in the author.yml file which was previously giving NOT_FOUND error.

**Screenshot**
<img width="1908" height="803" alt="Screenshot 2026-08-02 161645" src="https://github.com/user-attachments/assets/ae4e7012-bfc9-4526-9c65-c4be5450ea53" />


* **Which issue(s) this PR fixes**:
* This PR fixes issues #561.
