### PR TITLE
Fix Open Innovation supporter link (#562)

### DIFF
--- a/src/components/Supporters/index.js
+++ b/src/components/Supporters/index.js
@@ -146,7 +146,7 @@ const supporters = [
     imgSrc: "img/landing/logo_openinnovation.png",
     imgWidth: "100px",
     imgHeight: "60px",
-    url: "https://www.openinnovation.ai/"
+    url: "https://openinnovation.ai/"
   }
 ];
 


### PR DESCRIPTION
## Summary
- Fixes #562
- Updates the Open Innovation supporter URL from `https://www.openinnovation.ai/` to `https://openinnovation.ai/` (www redirects there; apex returns 200)
- Leaves `https://www.leinao.ai/` unchanged — that is still the official domain; it currently serves a maintenance page (`网站维护中`, HTTP 503). No replacement URL found. Happy to remove the logo temporarily if maintainers prefer

## Test plan

- [x]  Open Innovation logo on the Supporters section → lands on https://openinnovation.ai/
- [x] Confirm Leinao link still points to https://www.leinao.ai/ 

<img width="1710" height="1112" alt="Screenshot 2026-08-02 at 4 27 35 PM" src="https://github.com/user-attachments/assets/bde6cf0e-27ca-4f79-a5ea-c45c4e97abde" />
