### PR TITLE
fix: update zh-Hans footer copyright year to 2026

### DIFF
--- a/i18n/zh-Hans/docusaurus-theme-classic/footer.json
+++ b/i18n/zh-Hans/docusaurus-theme-classic/footer.json
@@ -1,6 +1,6 @@
 {
   "copyright": {
-    "message": "\n        <div class=\"footer-content\">\n          <p>Volcano是 <a href=\"https://www.cncf.io/\" target=\"_blank\" rel=\"noopener noreferrer\">云原生计算基金会</a> 孵化项目</p>\n          <div class=\"footer__logo-container\">\n            <img class=\"footer__logo\" alt=\"云原生计算基金会徽标\" src=\"/img/landing/logo_cloudnative.png\" />\n          </div>\n          <p>Linux基金会已注册并使用其商标。有关Linux基金会的商标列表，请参见 <a href=\"https://www.linuxfoundation.org/trademark-usage\" target=\"_blank\" rel=\"noopener noreferrer\">商标使用</a> 页面。</p>\n          <p>版权所有 © 2025 Volcano 项目作者所有。保留一切权利。</p>\n      ",
+    "message": "\n        <div class=\"footer-content\">\n          <p>Volcano是 <a href=\"https://www.cncf.io/\" target=\"_blank\" rel=\"noopener noreferrer\">云原生计算基金会</a> 孵化项目</p>\n          <div class=\"footer__logo-container\">\n            <img class=\"footer__logo\" alt=\"云原生计算基金会徽标\" src=\"/img/landing/logo_cloudnative.png\" />\n          </div>\n          <p>Linux基金会已注册并使用其商标。有关Linux基金会的商标列表，请参见 <a href=\"https://www.linuxfoundation.org/trademark-usage\" target=\"_blank\" rel=\"noopener noreferrer\">商标使用</a> 页面。</p>\n          <p>版权所有 © 2026 Volcano 项目作者所有。保留一切权利。</p>\n      ",
     "description": "The footer copyright"
   }
 }


### PR DESCRIPTION
The Chinese footer still shows the 2025 copyright year. The English footer
computes it dynamically with `new Date().getFullYear()`, but the zh-Hans
translation has the year hardcoded, so it went stale.

Updated it to 2026.

Fixes #540